### PR TITLE
Turn traps into their own class

### DIFF
--- a/src/wasm-v8-lowlevel.cc
+++ b/src/wasm-v8-lowlevel.cc
@@ -73,6 +73,11 @@ auto object_is_memory(v8::Local<v8::Object> obj) -> bool {
   return v8_obj->IsWasmMemoryObject();
 }
 
+auto object_is_error(v8::Local<v8::Object> obj) -> bool {
+  auto v8_obj = v8::Utils::OpenHandle(*obj);
+  return v8_obj->IsJSError();
+}
+
 
 
 // Foreign pointers

--- a/src/wasm-v8-lowlevel.hh
+++ b/src/wasm-v8-lowlevel.hh
@@ -15,6 +15,7 @@ auto object_is_func(v8::Local<v8::Object>) -> bool;
 auto object_is_global(v8::Local<v8::Object>) -> bool;
 auto object_is_table(v8::Local<v8::Object>) -> bool;
 auto object_is_memory(v8::Local<v8::Object>) -> bool;
+auto object_is_error(v8::Local<v8::Object>) -> bool;
 
 auto foreign_new(v8::Isolate*, void*) -> v8::Local<v8::Value>;
 auto foreign_get(v8::Local<v8::Value>) -> void*;


### PR DESCRIPTION
* Introduce a reference type wasm::Trap / wasm_trap_t to represent traps (backed by a JS Error instance -- enables them to maintain stack traces etc).
* Change Result / wasm_result_t to carry a trap instead of just a message in the trap case.
* Adjust examples.
* Fix wasm_name_new_from_string.