### PR TITLE
Don't store native float/double in wasm_val_t/Val.

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -11,16 +11,16 @@
 void wasm_val_print(wasm_val_t val) {
   switch (val.kind) {
     case WASM_I32: {
-      printf("%" PRIu32, val.of.i32);
+      printf("%" PRIu32, wasm_val_i32(&val));
     } break;
     case WASM_I64: {
-      printf("%" PRIu64, val.of.i64);
+      printf("%" PRIu64, wasm_val_i64(&val));
     } break;
     case WASM_F32: {
-      printf("%f", val.of.f32);
+      printf("%f", wasm_val_f32(&val));
     } break;
     case WASM_F64: {
-      printf("%g", val.of.f64);
+      printf("%g", wasm_val_f64(&val));
     } break;
     case WASM_ANYREF:
     case WASM_FUNCREF: {

--- a/example/global.c
+++ b/example/global.c
@@ -35,7 +35,7 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 
 
 #define check(val, type, expected) \
-  if (val.of.type != expected) { \
+  if (wasm_val_ ## type(&(val)) != (expected)) { \
     printf("> Error reading value\n"); \
     exit(1); \
   }
@@ -99,11 +99,13 @@ int main(int argc, const char* argv[]) {
   own wasm_globaltype_t* var_i64_type = wasm_globaltype_new(
     wasm_valtype_new(WASM_I64), WASM_VAR);
 
-  wasm_val_t val_f32_1 = {.kind = WASM_F32, .of = {.f32 = 1}};
+  wasm_val_t val_f32_1;
+  wasm_val_init_f32(&val_f32_1, 1);
   own wasm_global_t* const_f32_import = wasm_global_new(store, const_f32_type, &val_f32_1);
   wasm_val_t val_i64_2 = {.kind = WASM_I64, .of = {.i64 = 2}};
   own wasm_global_t* const_i64_import = wasm_global_new(store, const_i64_type, &val_i64_2);
-  wasm_val_t val_f32_3 = {.kind = WASM_F32, .of = {.f32 = 3}};
+  wasm_val_t val_f32_3;
+  wasm_val_init_f32(&val_f32_3, 3);
   own wasm_global_t* var_f32_import = wasm_global_new(store, var_f32_type, &val_f32_3);
   wasm_val_t val_i64_4 = {.kind = WASM_I64, .of = {.i64 = 4}};
   own wasm_global_t* var_i64_import = wasm_global_new(store, var_i64_type, &val_i64_4);
@@ -175,11 +177,13 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, f64, f64_reinterpret_i64(8));
 
   // Modify variables through API and check again.
-  wasm_val_t val33 = {.kind = WASM_F32, .of = {.f32 = 33}};
+  wasm_val_t val33;
+  wasm_val_init_f32(&val33, 33);
   wasm_global_set(var_f32_import, &val33);
   wasm_val_t val34 = {.kind = WASM_I64, .of = {.i64 = 34}};
   wasm_global_set(var_i64_import, &val34);
-  wasm_val_t val37 = {.kind = WASM_F32, .of = {.f32 = 37}};
+  wasm_val_t val37;
+  wasm_val_init_f32(&val37, 37);
   wasm_global_set(var_f32_export, &val37);
   wasm_val_t val38 = {.kind = WASM_I64, .of = {.i64 = 38}};
   wasm_global_set(var_i64_export, &val38);
@@ -196,19 +200,23 @@ int main(int argc, const char* argv[]) {
 
   // Modify variables through calls and check again.
   wasm_result_t result;
-  wasm_val_t val73 = {.kind = WASM_F32, .of = {.f32 = 73}};
+  wasm_val_t val73;
+  wasm_val_init_f32(&val73, 73);
   wasm_val_vec_t args73 = { 1, &val73 };
   wasm_func_call(set_var_f32_import, &args73, &result);
   wasm_result_delete(&result);
-  wasm_val_t val74 = {.kind = WASM_F64, .of = {.f64 = f64_reinterpret_i64(74)}};
+  wasm_val_t val74;
+  wasm_val_init_f64(&val74, f64_reinterpret_i64(74));
   wasm_val_vec_t args74 = { 1, &val74 };
   wasm_func_call(set_var_i64_import, &args74, &result);
   wasm_result_delete(&result);
-  wasm_val_t val77 = {.kind = WASM_F32, .of = {.f32 = 77}};
+  wasm_val_t val77;
+  wasm_val_init_f32(&val77, 77);
   wasm_val_vec_t args77 = { 1, &val77 };
   wasm_func_call(set_var_f32_export, &args77, &result);
   wasm_result_delete(&result);
-  wasm_val_t val78 = {.kind = WASM_F64, .of = {.f64 = f64_reinterpret_i64(78)}};
+  wasm_val_t val78;
+  wasm_val_init_f64(&val78, f64_reinterpret_i64(78));
   wasm_val_vec_t args78 = { 1, &val78 };
   wasm_func_call(set_var_i64_export, &args78, &result);
   wasm_result_delete(&result);

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -301,8 +301,6 @@ typedef struct wasm_val_t {
   union {
     int32_t i32;
     int64_t i64;
-    float32_t f32;
-    float64_t f64;
     struct wasm_ref_t* ref;
   } of;
 } wasm_val_t;
@@ -702,10 +700,76 @@ static inline void wasm_val_init_ptr(own wasm_val_t* out, void* p) {
 
 static inline void* wasm_val_ptr(const wasm_val_t* val) {
 #if UINTPTR_MAX == UINT32_MAX
+  assert(val->kind == WASM_I32);
   return (void*)(intptr_t)val->of.i32;
 #elif UINTPTR_MAX == UINT64_MAX
+  assert(val->kind == WASM_I64);
   return (void*)(intptr_t)val->of.i64;
 #endif
+}
+
+static inline void wasm_val_init_i32(own wasm_val_t* out, int32_t i) {
+  out->kind = WASM_I32;
+  out->of.i32 = i;
+}
+
+static inline int32_t wasm_val_i32(const wasm_val_t* val) {
+  assert(val->kind == WASM_I32);
+  return val->of.i32;
+}
+
+static inline void wasm_val_init_i64(own wasm_val_t* out, int64_t i) {
+  out->kind = WASM_I64;
+  out->of.i64 = i;
+}
+
+static inline int64_t wasm_val_i64(const wasm_val_t* val) {
+  assert(val->kind == WASM_I64);
+  return val->of.i64;
+}
+
+static inline void wasm_val_init_f32(own wasm_val_t* out, float32_t f) {
+  out->kind = WASM_F32;
+  memcpy(&out->of.i32, &f, sizeof(float32_t));
+}
+
+static inline float32_t wasm_val_f32(const wasm_val_t* val) {
+  assert(val->kind == WASM_F32);
+  float32_t f;
+  memcpy(&f, &val->of.i32, sizeof(float32_t));
+  return f;
+}
+
+static inline void wasm_val_init_f64(own wasm_val_t* out, float64_t f) {
+  out->kind = WASM_F64;
+  memcpy(&out->of.i64, &f, sizeof(float64_t));
+}
+
+static inline float64_t wasm_val_f64(const wasm_val_t* val) {
+  assert(val->kind == WASM_F64);
+  float64_t f;
+  memcpy(&f, &val->of.i64, sizeof(float64_t));
+  return f;
+}
+
+static inline void wasm_val_init_f32_bits(own wasm_val_t* out, int32_t i) {
+  out->kind = WASM_F32;
+  out->of.i32 = i;
+}
+
+static inline int32_t wasm_val_f32_bits(const wasm_val_t* val) {
+  assert(val->kind == WASM_F32);
+  return val->of.i32;
+}
+
+static inline void wasm_val_init_f64_bits(own wasm_val_t* out, int64_t i) {
+  out->kind = WASM_F64;
+  out->of.i64 = i;
+}
+
+static inline int64_t wasm_val_f64_bits(const wasm_val_t* val) {
+  assert(val->kind == WASM_F64);
+  return val->of.i64;
 }
 
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -567,8 +567,8 @@ inline auto hide(Val v) -> wasm_val_t {
   switch (v.kind()) {
     case I32: v2.of.i32 = v.i32(); break;
     case I64: v2.of.i64 = v.i64(); break;
-    case F32: v2.of.f32 = v.f32(); break;
-    case F64: v2.of.f64 = v.f64(); break;
+    case F32: v2.of.i32 = v.f32_bits(); break;
+    case F64: v2.of.i64 = v.f64_bits(); break;
     case ANYREF:
     case FUNCREF: v2.of.ref = hide(v.ref()); break;
     default: assert(false);
@@ -581,8 +581,8 @@ inline auto release(Val v) -> wasm_val_t {
   switch (v.kind()) {
     case I32: v2.of.i32 = v.i32(); break;
     case I64: v2.of.i64 = v.i64(); break;
-    case F32: v2.of.f32 = v.f32(); break;
-    case F64: v2.of.f64 = v.f64(); break;
+    case F32: v2.of.i32 = v.f32_bits(); break;
+    case F64: v2.of.i64 = v.f64_bits(); break;
     case ANYREF:
     case FUNCREF: v2.of.ref = release(v.release_ref()); break;
     default: assert(false);
@@ -594,8 +594,8 @@ inline auto adopt(wasm_val_t v) -> Val {
   switch (reveal(v.kind)) {
     case I32: return Val(v.of.i32);
     case I64: return Val(v.of.i64);
-    case F32: return Val(v.of.f32);
-    case F64: return Val(v.of.f64);
+    case F32: return Val::f32_bits(v.of.i32);
+    case F64: return Val::f64_bits(v.of.i64);
     case ANYREF:
     case FUNCREF: return Val(adopt(v.of.ref));
     default: assert(false);
@@ -614,8 +614,8 @@ inline auto borrow(const wasm_val_t* v) -> borrowed_val {
   switch (reveal(v->kind)) {
     case I32: v2 = Val(v->of.i32); break;
     case I64: v2 = Val(v->of.i64); break;
-    case F32: v2 = Val(v->of.f32); break;
-    case F64: v2 = Val(v->of.f64); break;
+    case F32: v2 = Val::f32_bits(v->of.i32); break;
+    case F64: v2 = Val::f64_bits(v->of.i64); break;
     case ANYREF:
     case FUNCREF: v2 = Val(adopt(v->of.ref)); break;
     default: assert(false);


### PR DESCRIPTION
Here's a possible approach to fixing #46, avoiding native float/double internally, but providing convenience routines for users that want them.