### PR TITLE
Fixed several memory leaks in Func

### DIFF
--- a/example/threads.c
+++ b/example/threads.c
@@ -88,6 +88,8 @@ void* run(void* args_abs) {
   wasm_module_delete(module);
   wasm_store_delete(store);
 
+  free(args_abs);
+
   return NULL;
 }
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -762,7 +762,7 @@ auto wasm_callback_with_env(
 
 void wasm_callback_env_finalizer(void* env) {
   auto t = static_cast<wasm_callback_env_t*>(env);
-  t->finalizer(t->env);
+  if (t->finalizer) t->finalizer(t->env);
   delete t;
 }
 
@@ -781,7 +781,7 @@ wasm_func_t *wasm_func_new_with_env(
   wasm_func_callback_with_env_t callback, void *env, void (*finalizer)(void*)
 ) {
   auto env2 = new wasm_callback_env_t{callback, env, finalizer};
-  return release(Func::make(store, type, wasm_callback_with_env, env2));
+  return release(Func::make(store, type, wasm_callback_with_env, env2, wasm_callback_env_finalizer));
 }
 
 wasm_functype_t* wasm_func_type(const wasm_func_t* func) {


### PR DESCRIPTION
During the execution of the tests, there were several memory leaks reported by address-sanitizer. 

- `handle_pool_` in `StoreImpl` created an array of references that was never freeds. Since the handles were maintained in a linked list, change the creation to initialize a linked list, and to have that linked list freed on destruction.

- `FuncData` did not have a finalizer to allow the void pointer `data` to be destroyed at the right time. Updated `Func` and `FuncData` to properly clear the data at finalization time.

- `FuncData::v8_callback` allocated an `args` and `results` list to pass along to the callback, but failed to delete them. Fixed.

- `threads.c` created a thread_arg struct to pass to the created threads, but nothing deleted them. Had the threads deallocate their own args object.