### PR TITLE
Don't leak implementation into headers.

### DIFF
--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -111,13 +111,8 @@ class vec {
   size_t size_;
   std::unique_ptr<T[]> data_;
 
-#ifdef DEBUG
   void make_data();
   void free_data();
-#else
-  void make_data() {}
-  void free_data() {}
-#endif
 
   vec(size_t size) : vec(size, size ? new(std::nothrow) T[size] : nullptr) {
     make_data();

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -210,6 +210,14 @@ Stats stats;
     if (data_) stats.free(Stats::STAT, data_.get(), Stats::VEC); \
   }
 
+#else
+
+#define DEFINE_VEC(type, STAT) \
+  template<> void vec<type>::make_data() {} \
+  template<> void vec<type>::free_data() {}
+
+#endif  // #ifdef DEBUG
+
 DEFINE_VEC(byte_t, BYTE)
 DEFINE_VEC(Frame*, FRAME)
 DEFINE_VEC(ValType*, VALTYPE)
@@ -230,8 +238,6 @@ DEFINE_VEC(Table*, TABLE)
 DEFINE_VEC(Memory*, MEMORY)
 DEFINE_VEC(Extern*, EXTERN)
 DEFINE_VEC(Val, VAL)
-
-#endif  // #ifdef DEBUG
 
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously, both: embedding C/C++ application and the library had to
be built using the same DEBUG define, because vec<type>::make_data()
and vec<type>::free_data() were declared in the implementation when
built with DEBUG defined, and in the headers otherwise.

As a result, linking C/C++ application against library built with
different DEBUG define resulted in either: failed build or broken
make/free accounting and the library aborting at runtime.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>