### PR TITLE
Add WASM_C_API to declarations that may need declspec(dllimport/dllexport) on Windows

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -9,6 +9,9 @@
 #include <string.h>
 #include <assert.h>
 
+#ifndef WASM_C_API
+#define WASM_C_API
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,7 +64,7 @@ typedef double float64_t;
 #define WASM_DECLARE_OWN(name) \
   typedef struct wasm_##name##_t wasm_##name##_t; \
   \
-  void wasm_##name##_delete(own wasm_##name##_t*);
+  WASM_C_API void wasm_##name##_delete(own wasm_##name##_t*);
 
 
 // Vectors
@@ -72,15 +75,15 @@ typedef double float64_t;
     wasm_##name##_t ptr_or_none* data; \
   } wasm_##name##_vec_t; \
   \
-  void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
-  void wasm_##name##_vec_new_uninitialized( \
+  WASM_C_API void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
+  WASM_C_API void wasm_##name##_vec_new_uninitialized( \
     own wasm_##name##_vec_t* out, size_t); \
-  void wasm_##name##_vec_new( \
+  WASM_C_API void wasm_##name##_vec_new( \
     own wasm_##name##_vec_t* out, \
     size_t, own wasm_##name##_t ptr_or_none const[]); \
-  void wasm_##name##_vec_copy( \
+  WASM_C_API void wasm_##name##_vec_copy( \
     own wasm_##name##_vec_t* out, const wasm_##name##_vec_t*); \
-  void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
+  WASM_C_API void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
 
 
 // Byte vectors
@@ -111,7 +114,7 @@ static inline void wasm_name_new_from_string(
 
 WASM_DECLARE_OWN(config)
 
-own wasm_config_t* wasm_config_new();
+WASM_C_API own wasm_config_t* wasm_config_new();
 
 // Embedders may provide custom functions for manipulating configs.
 
@@ -120,15 +123,15 @@ own wasm_config_t* wasm_config_new();
 
 WASM_DECLARE_OWN(engine)
 
-own wasm_engine_t* wasm_engine_new();
-own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
+WASM_C_API own wasm_engine_t* wasm_engine_new();
+WASM_C_API own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
 
 // Store
 
 WASM_DECLARE_OWN(store)
 
-own wasm_store_t* wasm_store_new(wasm_engine_t*);
+WASM_C_API own wasm_store_t* wasm_store_new(wasm_engine_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -156,7 +159,7 @@ static const uint32_t wasm_limits_max_default = 0xffffffff;
   WASM_DECLARE_OWN(name) \
   WASM_DECLARE_VEC(name, *) \
   \
-  own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
+  WASM_C_API own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
 
 
 // Value Types
@@ -173,9 +176,9 @@ enum wasm_valkind_enum {
   WASM_FUNCREF,
 };
 
-own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
+WASM_C_API own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
 
-wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
+WASM_C_API wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
 
 static inline bool wasm_valkind_is_num(wasm_valkind_t k) {
   return k < WASM_ANYREF;
@@ -196,42 +199,42 @@ static inline bool wasm_valtype_is_ref(const wasm_valtype_t* t) {
 
 WASM_DECLARE_TYPE(functype)
 
-own wasm_functype_t* wasm_functype_new(
+WASM_C_API own wasm_functype_t* wasm_functype_new(
   own wasm_valtype_vec_t* params, own wasm_valtype_vec_t* results);
 
-const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
-const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
+WASM_C_API const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
+WASM_C_API const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
 
 
 // Global Types
 
 WASM_DECLARE_TYPE(globaltype)
 
-own wasm_globaltype_t* wasm_globaltype_new(
+WASM_C_API own wasm_globaltype_t* wasm_globaltype_new(
   own wasm_valtype_t*, wasm_mutability_t);
 
-const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
-wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
+WASM_C_API const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
+WASM_C_API wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
 
 
 // Table Types
 
 WASM_DECLARE_TYPE(tabletype)
 
-own wasm_tabletype_t* wasm_tabletype_new(
+WASM_C_API own wasm_tabletype_t* wasm_tabletype_new(
   own wasm_valtype_t*, const wasm_limits_t*);
 
-const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
-const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
+WASM_C_API const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
+WASM_C_API const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
 
 
 // Memory Types
 
 WASM_DECLARE_TYPE(memorytype)
 
-own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
+WASM_C_API own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
 
-const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
+WASM_C_API const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
 
 
 // Extern Types
@@ -246,50 +249,50 @@ enum wasm_externkind_enum {
   WASM_EXTERN_MEMORY,
 };
 
-wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
+WASM_C_API wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
 
-wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
-wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
-wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
-wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
+WASM_C_API wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
+WASM_C_API wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
+WASM_C_API wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
+WASM_C_API wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
 
-wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
-wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
-wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
-wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
+WASM_C_API wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
+WASM_C_API wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
+WASM_C_API wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
+WASM_C_API wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
 
-const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
-const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
-const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
-const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
+WASM_C_API const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
+WASM_C_API const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
+WASM_C_API const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
+WASM_C_API const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
 
-const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
-const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
-const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
-const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
+WASM_C_API const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
+WASM_C_API const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
+WASM_C_API const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
+WASM_C_API const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
 
 
 // Import Types
 
 WASM_DECLARE_TYPE(importtype)
 
-own wasm_importtype_t* wasm_importtype_new(
+WASM_C_API own wasm_importtype_t* wasm_importtype_new(
   own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
 
-const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
-const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
-const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
+WASM_C_API const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
+WASM_C_API const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
+WASM_C_API const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
 
 
 // Export Types
 
 WASM_DECLARE_TYPE(exporttype)
 
-own wasm_exporttype_t* wasm_exporttype_new(
+WASM_C_API own wasm_exporttype_t* wasm_exporttype_new(
   own wasm_name_t*, own wasm_externtype_t*);
 
-const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
-const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
+WASM_C_API const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
+WASM_C_API const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -310,8 +313,8 @@ typedef struct wasm_val_t {
   } of;
 } wasm_val_t;
 
-void wasm_val_delete(own wasm_val_t* v);
-void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
+WASM_C_API void wasm_val_delete(own wasm_val_t* v);
+WASM_C_API void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
 
 WASM_DECLARE_VEC(val, )
 
@@ -321,28 +324,28 @@ WASM_DECLARE_VEC(val, )
 #define WASM_DECLARE_REF_BASE(name) \
   WASM_DECLARE_OWN(name) \
   \
-  own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
-  bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
+  WASM_C_API own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
+  WASM_C_API bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
   \
-  void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
-  void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
-  void wasm_##name##_set_host_info_with_finalizer( \
+  WASM_C_API void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
+  WASM_C_API void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
+  WASM_C_API void wasm_##name##_set_host_info_with_finalizer( \
     wasm_##name##_t*, void*, void (*)(void*));
 
 #define WASM_DECLARE_REF(name) \
   WASM_DECLARE_REF_BASE(name) \
   \
-  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
-  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
-  const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
-  const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
+  WASM_C_API wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
+  WASM_C_API wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
+  WASM_C_API const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
+  WASM_C_API const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
 
 #define WASM_DECLARE_SHARABLE_REF(name) \
   WASM_DECLARE_REF(name) \
   WASM_DECLARE_OWN(shared_##name) \
   \
-  own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
-  own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
+  WASM_C_API own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
+  WASM_C_API own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
 
 
 WASM_DECLARE_REF_BASE(ref)
@@ -352,12 +355,12 @@ WASM_DECLARE_REF_BASE(ref)
 
 WASM_DECLARE_OWN(frame)
 WASM_DECLARE_VEC(frame, *)
-own wasm_frame_t* wasm_frame_copy(const wasm_frame_t*);
+WASM_C_API own wasm_frame_t* wasm_frame_copy(const wasm_frame_t*);
 
-struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
-uint32_t wasm_frame_func_index(const wasm_frame_t*);
-size_t wasm_frame_func_offset(const wasm_frame_t*);
-size_t wasm_frame_module_offset(const wasm_frame_t*);
+WASM_C_API struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
+WASM_C_API uint32_t wasm_frame_func_index(const wasm_frame_t*);
+WASM_C_API size_t wasm_frame_func_offset(const wasm_frame_t*);
+WASM_C_API size_t wasm_frame_module_offset(const wasm_frame_t*);
 
 
 // Traps
@@ -366,34 +369,34 @@ typedef wasm_name_t wasm_message_t;  // null terminated
 
 WASM_DECLARE_REF(trap)
 
-own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
+WASM_C_API own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
 
-void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
-own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
-void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
+WASM_C_API void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
+WASM_C_API own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
+WASM_C_API void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
 
 
 // Foreign Objects
 
 WASM_DECLARE_REF(foreign)
 
-own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
+WASM_C_API own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
 
 
 // Modules
 
 WASM_DECLARE_SHARABLE_REF(module)
 
-own wasm_module_t* wasm_module_new(
+WASM_C_API own wasm_module_t* wasm_module_new(
   wasm_store_t*, const wasm_byte_vec_t* binary);
 
-bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
+WASM_C_API bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
 
-void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
-void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
+WASM_C_API void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
+WASM_C_API void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 
-void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
-own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
+WASM_C_API void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
+WASM_C_API own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
 
 
 // Function Instances
@@ -405,17 +408,17 @@ typedef own wasm_trap_t* (*wasm_func_callback_t)(
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
   void* env, const wasm_val_t args[], wasm_val_t results[]);
 
-own wasm_func_t* wasm_func_new(
+WASM_C_API own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
-own wasm_func_t* wasm_func_new_with_env(
+WASM_C_API own wasm_func_t* wasm_func_new_with_env(
   wasm_store_t*, const wasm_functype_t* type, wasm_func_callback_with_env_t,
   void* env, void (*finalizer)(void*));
 
-own wasm_functype_t* wasm_func_type(const wasm_func_t*);
-size_t wasm_func_param_arity(const wasm_func_t*);
-size_t wasm_func_result_arity(const wasm_func_t*);
+WASM_C_API own wasm_functype_t* wasm_func_type(const wasm_func_t*);
+WASM_C_API size_t wasm_func_param_arity(const wasm_func_t*);
+WASM_C_API size_t wasm_func_result_arity(const wasm_func_t*);
 
-own wasm_trap_t* wasm_func_call(
+WASM_C_API own wasm_trap_t* wasm_func_call(
   const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
 
 
@@ -423,13 +426,13 @@ own wasm_trap_t* wasm_func_call(
 
 WASM_DECLARE_REF(global)
 
-own wasm_global_t* wasm_global_new(
+WASM_C_API own wasm_global_t* wasm_global_new(
   wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
 
-own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
+WASM_C_API own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
-void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
-void wasm_global_set(wasm_global_t*, const wasm_val_t*);
+WASM_C_API void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
+WASM_C_API void wasm_global_set(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances
@@ -438,16 +441,16 @@ WASM_DECLARE_REF(table)
 
 typedef uint32_t wasm_table_size_t;
 
-own wasm_table_t* wasm_table_new(
+WASM_C_API own wasm_table_t* wasm_table_new(
   wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
 
-own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
+WASM_C_API own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
-own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
-bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
+WASM_C_API own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
+WASM_C_API bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
 
-wasm_table_size_t wasm_table_size(const wasm_table_t*);
-bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
+WASM_C_API wasm_table_size_t wasm_table_size(const wasm_table_t*);
+WASM_C_API bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
 
 
 // Memory Instances
@@ -458,15 +461,15 @@ typedef uint32_t wasm_memory_pages_t;
 
 static const size_t MEMORY_PAGE_SIZE = 0x10000;
 
-own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
+WASM_C_API own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
 
-own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
+WASM_C_API own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
 
-byte_t* wasm_memory_data(wasm_memory_t*);
-size_t wasm_memory_data_size(const wasm_memory_t*);
+WASM_C_API byte_t* wasm_memory_data(wasm_memory_t*);
+WASM_C_API size_t wasm_memory_data_size(const wasm_memory_t*);
 
-wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
-bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
+WASM_C_API wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
+WASM_C_API bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 
 
 // Externals
@@ -474,40 +477,40 @@ bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 WASM_DECLARE_REF(extern)
 WASM_DECLARE_VEC(extern, *)
 
-wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
-own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
+WASM_C_API wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
+WASM_C_API own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
 
-wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
-wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
-wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
-wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
+WASM_C_API wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
+WASM_C_API wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
+WASM_C_API wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
+WASM_C_API wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
 
-wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
-wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
-wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
-wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
+WASM_C_API wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
+WASM_C_API wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
+WASM_C_API wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
+WASM_C_API wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
 
-const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
-const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
-const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
-const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
+WASM_C_API const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
+WASM_C_API const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
+WASM_C_API const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
+WASM_C_API const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
 
-const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
-const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
-const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
-const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
+WASM_C_API const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
+WASM_C_API const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
+WASM_C_API const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
+WASM_C_API const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
 
 
 // Module Instances
 
 WASM_DECLARE_REF(instance)
 
-own wasm_instance_t* wasm_instance_new(
+WASM_C_API own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
   own wasm_trap_t**
 );
 
-void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
+WASM_C_API void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -10,7 +10,11 @@
 #include <assert.h>
 
 #ifndef WASM_C_API
+#ifdef _WIN32
+#define WASM_C_API __declspec(dllimport)
+#else
 #define WASM_C_API
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -9,11 +9,11 @@
 #include <string.h>
 #include <assert.h>
 
-#ifndef WASM_C_API
+#ifndef WASM_API_EXTERN
 #ifdef _WIN32
-#define WASM_C_API __declspec(dllimport)
+#define WASM_API_EXTERN __declspec(dllimport)
 #else
-#define WASM_C_API
+#define WASM_API_EXTERN
 #endif
 #endif
 
@@ -68,7 +68,7 @@ typedef double float64_t;
 #define WASM_DECLARE_OWN(name) \
   typedef struct wasm_##name##_t wasm_##name##_t; \
   \
-  WASM_C_API void wasm_##name##_delete(own wasm_##name##_t*);
+  WASM_API_EXTERN void wasm_##name##_delete(own wasm_##name##_t*);
 
 
 // Vectors
@@ -79,15 +79,15 @@ typedef double float64_t;
     wasm_##name##_t ptr_or_none* data; \
   } wasm_##name##_vec_t; \
   \
-  WASM_C_API void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
-  WASM_C_API void wasm_##name##_vec_new_uninitialized( \
+  WASM_API_EXTERN void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
+  WASM_API_EXTERN void wasm_##name##_vec_new_uninitialized( \
     own wasm_##name##_vec_t* out, size_t); \
-  WASM_C_API void wasm_##name##_vec_new( \
+  WASM_API_EXTERN void wasm_##name##_vec_new( \
     own wasm_##name##_vec_t* out, \
     size_t, own wasm_##name##_t ptr_or_none const[]); \
-  WASM_C_API void wasm_##name##_vec_copy( \
+  WASM_API_EXTERN void wasm_##name##_vec_copy( \
     own wasm_##name##_vec_t* out, const wasm_##name##_vec_t*); \
-  WASM_C_API void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
+  WASM_API_EXTERN void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
 
 
 // Byte vectors
@@ -118,7 +118,7 @@ static inline void wasm_name_new_from_string(
 
 WASM_DECLARE_OWN(config)
 
-WASM_C_API own wasm_config_t* wasm_config_new();
+WASM_API_EXTERN own wasm_config_t* wasm_config_new();
 
 // Embedders may provide custom functions for manipulating configs.
 
@@ -127,15 +127,15 @@ WASM_C_API own wasm_config_t* wasm_config_new();
 
 WASM_DECLARE_OWN(engine)
 
-WASM_C_API own wasm_engine_t* wasm_engine_new();
-WASM_C_API own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
+WASM_API_EXTERN own wasm_engine_t* wasm_engine_new();
+WASM_API_EXTERN own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
 
 // Store
 
 WASM_DECLARE_OWN(store)
 
-WASM_C_API own wasm_store_t* wasm_store_new(wasm_engine_t*);
+WASM_API_EXTERN own wasm_store_t* wasm_store_new(wasm_engine_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -163,7 +163,7 @@ static const uint32_t wasm_limits_max_default = 0xffffffff;
   WASM_DECLARE_OWN(name) \
   WASM_DECLARE_VEC(name, *) \
   \
-  WASM_C_API own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
+  WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
 
 
 // Value Types
@@ -180,9 +180,9 @@ enum wasm_valkind_enum {
   WASM_FUNCREF,
 };
 
-WASM_C_API own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
+WASM_API_EXTERN own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
 
-WASM_C_API wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
+WASM_API_EXTERN wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
 
 static inline bool wasm_valkind_is_num(wasm_valkind_t k) {
   return k < WASM_ANYREF;
@@ -203,42 +203,42 @@ static inline bool wasm_valtype_is_ref(const wasm_valtype_t* t) {
 
 WASM_DECLARE_TYPE(functype)
 
-WASM_C_API own wasm_functype_t* wasm_functype_new(
+WASM_API_EXTERN own wasm_functype_t* wasm_functype_new(
   own wasm_valtype_vec_t* params, own wasm_valtype_vec_t* results);
 
-WASM_C_API const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
-WASM_C_API const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
+WASM_API_EXTERN const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
+WASM_API_EXTERN const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
 
 
 // Global Types
 
 WASM_DECLARE_TYPE(globaltype)
 
-WASM_C_API own wasm_globaltype_t* wasm_globaltype_new(
+WASM_API_EXTERN own wasm_globaltype_t* wasm_globaltype_new(
   own wasm_valtype_t*, wasm_mutability_t);
 
-WASM_C_API const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
-WASM_C_API wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
+WASM_API_EXTERN const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
+WASM_API_EXTERN wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
 
 
 // Table Types
 
 WASM_DECLARE_TYPE(tabletype)
 
-WASM_C_API own wasm_tabletype_t* wasm_tabletype_new(
+WASM_API_EXTERN own wasm_tabletype_t* wasm_tabletype_new(
   own wasm_valtype_t*, const wasm_limits_t*);
 
-WASM_C_API const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
-WASM_C_API const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
+WASM_API_EXTERN const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
+WASM_API_EXTERN const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
 
 
 // Memory Types
 
 WASM_DECLARE_TYPE(memorytype)
 
-WASM_C_API own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
+WASM_API_EXTERN own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
 
-WASM_C_API const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
+WASM_API_EXTERN const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
 
 
 // Extern Types
@@ -253,50 +253,50 @@ enum wasm_externkind_enum {
   WASM_EXTERN_MEMORY,
 };
 
-WASM_C_API wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
+WASM_API_EXTERN wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
 
-WASM_C_API wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
-WASM_C_API wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
-WASM_C_API wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
-WASM_C_API wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
+WASM_API_EXTERN wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
+WASM_API_EXTERN wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
+WASM_API_EXTERN wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
+WASM_API_EXTERN wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
 
-WASM_C_API wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
-WASM_C_API wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
-WASM_C_API wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
-WASM_C_API wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
+WASM_API_EXTERN wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
+WASM_API_EXTERN wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
+WASM_API_EXTERN wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
+WASM_API_EXTERN wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
 
-WASM_C_API const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
-WASM_C_API const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
-WASM_C_API const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
-WASM_C_API const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
 
-WASM_C_API const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
-WASM_C_API const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
-WASM_C_API const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
-WASM_C_API const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
+WASM_API_EXTERN const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
+WASM_API_EXTERN const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
+WASM_API_EXTERN const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
+WASM_API_EXTERN const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
 
 
 // Import Types
 
 WASM_DECLARE_TYPE(importtype)
 
-WASM_C_API own wasm_importtype_t* wasm_importtype_new(
+WASM_API_EXTERN own wasm_importtype_t* wasm_importtype_new(
   own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
 
-WASM_C_API const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
-WASM_C_API const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
-WASM_C_API const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
+WASM_API_EXTERN const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
+WASM_API_EXTERN const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
 
 
 // Export Types
 
 WASM_DECLARE_TYPE(exporttype)
 
-WASM_C_API own wasm_exporttype_t* wasm_exporttype_new(
+WASM_API_EXTERN own wasm_exporttype_t* wasm_exporttype_new(
   own wasm_name_t*, own wasm_externtype_t*);
 
-WASM_C_API const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
-WASM_C_API const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
+WASM_API_EXTERN const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
+WASM_API_EXTERN const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -317,8 +317,8 @@ typedef struct wasm_val_t {
   } of;
 } wasm_val_t;
 
-WASM_C_API void wasm_val_delete(own wasm_val_t* v);
-WASM_C_API void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
+WASM_API_EXTERN void wasm_val_delete(own wasm_val_t* v);
+WASM_API_EXTERN void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
 
 WASM_DECLARE_VEC(val, )
 
@@ -328,28 +328,28 @@ WASM_DECLARE_VEC(val, )
 #define WASM_DECLARE_REF_BASE(name) \
   WASM_DECLARE_OWN(name) \
   \
-  WASM_C_API own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
-  WASM_C_API bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
+  WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
+  WASM_API_EXTERN bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
   \
-  WASM_C_API void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
-  WASM_C_API void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
-  WASM_C_API void wasm_##name##_set_host_info_with_finalizer( \
+  WASM_API_EXTERN void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
+  WASM_API_EXTERN void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
+  WASM_API_EXTERN void wasm_##name##_set_host_info_with_finalizer( \
     wasm_##name##_t*, void*, void (*)(void*));
 
 #define WASM_DECLARE_REF(name) \
   WASM_DECLARE_REF_BASE(name) \
   \
-  WASM_C_API wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
-  WASM_C_API wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
-  WASM_C_API const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
-  WASM_C_API const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
+  WASM_API_EXTERN wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
+  WASM_API_EXTERN wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
+  WASM_API_EXTERN const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
+  WASM_API_EXTERN const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
 
 #define WASM_DECLARE_SHARABLE_REF(name) \
   WASM_DECLARE_REF(name) \
   WASM_DECLARE_OWN(shared_##name) \
   \
-  WASM_C_API own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
-  WASM_C_API own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
+  WASM_API_EXTERN own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
+  WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
 
 
 WASM_DECLARE_REF_BASE(ref)
@@ -359,12 +359,12 @@ WASM_DECLARE_REF_BASE(ref)
 
 WASM_DECLARE_OWN(frame)
 WASM_DECLARE_VEC(frame, *)
-WASM_C_API own wasm_frame_t* wasm_frame_copy(const wasm_frame_t*);
+WASM_API_EXTERN own wasm_frame_t* wasm_frame_copy(const wasm_frame_t*);
 
-WASM_C_API struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
-WASM_C_API uint32_t wasm_frame_func_index(const wasm_frame_t*);
-WASM_C_API size_t wasm_frame_func_offset(const wasm_frame_t*);
-WASM_C_API size_t wasm_frame_module_offset(const wasm_frame_t*);
+WASM_API_EXTERN struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
+WASM_API_EXTERN uint32_t wasm_frame_func_index(const wasm_frame_t*);
+WASM_API_EXTERN size_t wasm_frame_func_offset(const wasm_frame_t*);
+WASM_API_EXTERN size_t wasm_frame_module_offset(const wasm_frame_t*);
 
 
 // Traps
@@ -373,34 +373,34 @@ typedef wasm_name_t wasm_message_t;  // null terminated
 
 WASM_DECLARE_REF(trap)
 
-WASM_C_API own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
+WASM_API_EXTERN own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
 
-WASM_C_API void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
-WASM_C_API own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
-WASM_C_API void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
+WASM_API_EXTERN void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
+WASM_API_EXTERN own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
+WASM_API_EXTERN void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
 
 
 // Foreign Objects
 
 WASM_DECLARE_REF(foreign)
 
-WASM_C_API own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
+WASM_API_EXTERN own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
 
 
 // Modules
 
 WASM_DECLARE_SHARABLE_REF(module)
 
-WASM_C_API own wasm_module_t* wasm_module_new(
+WASM_API_EXTERN own wasm_module_t* wasm_module_new(
   wasm_store_t*, const wasm_byte_vec_t* binary);
 
-WASM_C_API bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
+WASM_API_EXTERN bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
 
-WASM_C_API void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
-WASM_C_API void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
+WASM_API_EXTERN void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
+WASM_API_EXTERN void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 
-WASM_C_API void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
-WASM_C_API own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
+WASM_API_EXTERN void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
+WASM_API_EXTERN own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
 
 
 // Function Instances
@@ -412,17 +412,17 @@ typedef own wasm_trap_t* (*wasm_func_callback_t)(
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
   void* env, const wasm_val_t args[], wasm_val_t results[]);
 
-WASM_C_API own wasm_func_t* wasm_func_new(
+WASM_API_EXTERN own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
-WASM_C_API own wasm_func_t* wasm_func_new_with_env(
+WASM_API_EXTERN own wasm_func_t* wasm_func_new_with_env(
   wasm_store_t*, const wasm_functype_t* type, wasm_func_callback_with_env_t,
   void* env, void (*finalizer)(void*));
 
-WASM_C_API own wasm_functype_t* wasm_func_type(const wasm_func_t*);
-WASM_C_API size_t wasm_func_param_arity(const wasm_func_t*);
-WASM_C_API size_t wasm_func_result_arity(const wasm_func_t*);
+WASM_API_EXTERN own wasm_functype_t* wasm_func_type(const wasm_func_t*);
+WASM_API_EXTERN size_t wasm_func_param_arity(const wasm_func_t*);
+WASM_API_EXTERN size_t wasm_func_result_arity(const wasm_func_t*);
 
-WASM_C_API own wasm_trap_t* wasm_func_call(
+WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
   const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
 
 
@@ -430,13 +430,13 @@ WASM_C_API own wasm_trap_t* wasm_func_call(
 
 WASM_DECLARE_REF(global)
 
-WASM_C_API own wasm_global_t* wasm_global_new(
+WASM_API_EXTERN own wasm_global_t* wasm_global_new(
   wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
 
-WASM_C_API own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
+WASM_API_EXTERN own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
-WASM_C_API void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
-WASM_C_API void wasm_global_set(wasm_global_t*, const wasm_val_t*);
+WASM_API_EXTERN void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
+WASM_API_EXTERN void wasm_global_set(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances
@@ -445,16 +445,16 @@ WASM_DECLARE_REF(table)
 
 typedef uint32_t wasm_table_size_t;
 
-WASM_C_API own wasm_table_t* wasm_table_new(
+WASM_API_EXTERN own wasm_table_t* wasm_table_new(
   wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
 
-WASM_C_API own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
+WASM_API_EXTERN own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
-WASM_C_API own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
-WASM_C_API bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
+WASM_API_EXTERN bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
 
-WASM_C_API wasm_table_size_t wasm_table_size(const wasm_table_t*);
-WASM_C_API bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
+WASM_API_EXTERN wasm_table_size_t wasm_table_size(const wasm_table_t*);
+WASM_API_EXTERN bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
 
 
 // Memory Instances
@@ -465,15 +465,15 @@ typedef uint32_t wasm_memory_pages_t;
 
 static const size_t MEMORY_PAGE_SIZE = 0x10000;
 
-WASM_C_API own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
+WASM_API_EXTERN own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
 
-WASM_C_API own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
+WASM_API_EXTERN own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
 
-WASM_C_API byte_t* wasm_memory_data(wasm_memory_t*);
-WASM_C_API size_t wasm_memory_data_size(const wasm_memory_t*);
+WASM_API_EXTERN byte_t* wasm_memory_data(wasm_memory_t*);
+WASM_API_EXTERN size_t wasm_memory_data_size(const wasm_memory_t*);
 
-WASM_C_API wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
-WASM_C_API bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
+WASM_API_EXTERN wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
+WASM_API_EXTERN bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 
 
 // Externals
@@ -481,40 +481,40 @@ WASM_C_API bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 WASM_DECLARE_REF(extern)
 WASM_DECLARE_VEC(extern, *)
 
-WASM_C_API wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
-WASM_C_API own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
+WASM_API_EXTERN wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
+WASM_API_EXTERN own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
 
-WASM_C_API wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
-WASM_C_API wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
-WASM_C_API wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
-WASM_C_API wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
+WASM_API_EXTERN wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
+WASM_API_EXTERN wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
+WASM_API_EXTERN wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
+WASM_API_EXTERN wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
 
-WASM_C_API wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
-WASM_C_API wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
-WASM_C_API wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
-WASM_C_API wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
+WASM_API_EXTERN wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
+WASM_API_EXTERN wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
+WASM_API_EXTERN wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
+WASM_API_EXTERN wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
 
-WASM_C_API const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
-WASM_C_API const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
-WASM_C_API const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
-WASM_C_API const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
+WASM_API_EXTERN const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
+WASM_API_EXTERN const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
+WASM_API_EXTERN const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
+WASM_API_EXTERN const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
 
-WASM_C_API const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
-WASM_C_API const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
-WASM_C_API const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
-WASM_C_API const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
+WASM_API_EXTERN const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
+WASM_API_EXTERN const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
+WASM_API_EXTERN const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
+WASM_API_EXTERN const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
 
 
 // Module Instances
 
 WASM_DECLARE_REF(instance)
 
-WASM_C_API own wasm_instance_t* wasm_instance_new(
+WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
   own wasm_trap_t**
 );
 
-WASM_C_API void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
+WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -11,8 +11,12 @@
 #include <limits>
 #include <string>
 
-#ifndef WASM_C_API
-#define WASM_C_API
+#ifndef WASM_API_EXTERN
+#ifdef _WIN32
+#define WASM_API_EXTERN __declspec(dllimport)
+#else
+#define WASM_API_EXTERN
+#endif
 #endif
 
 
@@ -43,8 +47,8 @@ class vec {
   std::unique_ptr<T[]> data_;
 
 #ifdef WASM_API_DEBUG
-  WASM_C_API void make_data();
-  WASM_C_API void free_data();
+  WASM_API_EXTERN void make_data();
+  WASM_API_EXTERN void free_data();
 #else
   void make_data() {}
   void free_data() {}
@@ -182,7 +186,7 @@ auto make_own(T* x) -> own<T> { return own<T>(x); }
 
 // Configuration
 
-class WASM_C_API Config {
+class WASM_API_EXTERN Config {
 public:
   Config() = delete;
   ~Config();
@@ -196,7 +200,7 @@ public:
 
 // Engine
 
-class WASM_C_API Engine {
+class WASM_API_EXTERN Engine {
 public:
   Engine() = delete;
   ~Engine();
@@ -208,7 +212,7 @@ public:
 
 // Store
 
-class WASM_C_API Store {
+class WASM_API_EXTERN Store {
 public:
   Store() = delete;
   ~Store();
@@ -245,7 +249,7 @@ inline bool is_num(ValKind k) { return k < ANYREF; }
 inline bool is_ref(ValKind k) { return k >= ANYREF; }
 
 
-class WASM_C_API ValType {
+class WASM_API_EXTERN ValType {
 public:
   ValType() = delete;
   ~ValType();
@@ -271,7 +275,7 @@ class GlobalType;
 class TableType;
 class MemoryType;
 
-class WASM_C_API ExternType {
+class WASM_API_EXTERN ExternType {
 public:
   ExternType() = delete;
   ~ExternType();
@@ -295,7 +299,7 @@ public:
 
 // Function Types
 
-class WASM_C_API FuncType : public ExternType {
+class WASM_API_EXTERN FuncType : public ExternType {
 public:
   FuncType() = delete;
   ~FuncType();
@@ -314,7 +318,7 @@ public:
 
 // Global Types
 
-class WASM_C_API GlobalType : public ExternType {
+class WASM_API_EXTERN GlobalType : public ExternType {
 public:
   GlobalType() = delete;
   ~GlobalType();
@@ -329,7 +333,7 @@ public:
 
 // Table Types
 
-class WASM_C_API TableType : public ExternType {
+class WASM_API_EXTERN TableType : public ExternType {
 public:
   TableType() = delete;
   ~TableType();
@@ -344,7 +348,7 @@ public:
 
 // Memory Types
 
-class WASM_C_API MemoryType : public ExternType {
+class WASM_API_EXTERN MemoryType : public ExternType {
 public:
   MemoryType() = delete;
   ~MemoryType();
@@ -360,7 +364,7 @@ public:
 
 using Name = vec<byte_t>;
 
-class WASM_C_API ImportType {
+class WASM_API_EXTERN ImportType {
 public:
   ImportType() = delete;
   ~ImportType();
@@ -378,7 +382,7 @@ public:
 
 // Export Types
 
-class WASM_C_API ExportType {
+class WASM_API_EXTERN ExportType {
 public:
   ExportType() = delete;
   ~ExportType();
@@ -397,7 +401,7 @@ public:
 
 // References
 
-class WASM_C_API Ref {
+class WASM_API_EXTERN Ref {
 public:
   Ref() = delete;
   ~Ref();
@@ -535,7 +539,7 @@ using Message = vec<byte_t>;  // null terminated
 
 class Instance;
 
-class WASM_C_API Frame {
+class WASM_API_EXTERN Frame {
 public:
   Frame() = delete;
   ~Frame();
@@ -549,7 +553,7 @@ public:
   auto module_offset() const -> size_t;
 };
 
-class WASM_C_API Trap : public Ref {
+class WASM_API_EXTERN Trap : public Ref {
 public:
   Trap() = delete;
   ~Trap();
@@ -566,7 +570,7 @@ public:
 // Shared objects
 
 template<class T>
-class WASM_C_API Shared {
+class WASM_API_EXTERN Shared {
 public:
   Shared() = delete;
   ~Shared();
@@ -576,7 +580,7 @@ public:
 
 // Modules
 
-class WASM_C_API Module : public Ref {
+class WASM_API_EXTERN Module : public Ref {
 public:
   Module() = delete;
   ~Module();
@@ -598,7 +602,7 @@ public:
 
 // Foreign Objects
 
-class WASM_C_API Foreign : public Ref {
+class WASM_API_EXTERN Foreign : public Ref {
 public:
   Foreign() = delete;
   ~Foreign();
@@ -615,7 +619,7 @@ class Global;
 class Table;
 class Memory;
 
-class WASM_C_API Extern : public Ref {
+class WASM_API_EXTERN Extern : public Ref {
 public:
   Extern() = delete;
   ~Extern();
@@ -639,7 +643,7 @@ public:
 
 // Function Instances
 
-class WASM_C_API Func : public Extern {
+class WASM_API_EXTERN Func : public Extern {
 public:
   Func() = delete;
   ~Func();
@@ -662,7 +666,7 @@ public:
 
 // Global Instances
 
-class WASM_C_API Global : public Extern {
+class WASM_API_EXTERN Global : public Extern {
 public:
   Global() = delete;
   ~Global();
@@ -678,7 +682,7 @@ public:
 
 // Table Instances
 
-class WASM_C_API Table : public Extern {
+class WASM_API_EXTERN Table : public Extern {
 public:
   Table() = delete;
   ~Table();
@@ -699,7 +703,7 @@ public:
 
 // Memory Instances
 
-class WASM_C_API Memory : public Extern {
+class WASM_API_EXTERN Memory : public Extern {
 public:
   Memory() = delete;
   ~Memory();
@@ -721,7 +725,7 @@ public:
 
 // Module Instances
 
-class WASM_C_API Instance : public Ref {
+class WASM_API_EXTERN Instance : public Ref {
 public:
   Instance() = delete;
   ~Instance();

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -11,6 +11,10 @@
 #include <limits>
 #include <string>
 
+#ifndef WASM_C_API
+#define WASM_C_API
+#endif
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // Auxiliaries
@@ -39,8 +43,8 @@ class vec {
   std::unique_ptr<T[]> data_;
 
 #ifdef WASM_API_DEBUG
-  void make_data();
-  void free_data();
+  WASM_C_API void make_data();
+  WASM_C_API void free_data();
 #else
   void make_data() {}
   void free_data() {}
@@ -178,7 +182,7 @@ auto make_own(T* x) -> own<T> { return own<T>(x); }
 
 // Configuration
 
-class Config {
+class WASM_C_API Config {
 public:
   Config() = delete;
   ~Config();
@@ -192,7 +196,7 @@ public:
 
 // Engine
 
-class Engine {
+class WASM_C_API Engine {
 public:
   Engine() = delete;
   ~Engine();
@@ -204,7 +208,7 @@ public:
 
 // Store
 
-class Store {
+class WASM_C_API Store {
 public:
   Store() = delete;
   ~Store();
@@ -241,7 +245,7 @@ inline bool is_num(ValKind k) { return k < ANYREF; }
 inline bool is_ref(ValKind k) { return k >= ANYREF; }
 
 
-class ValType {
+class WASM_C_API ValType {
 public:
   ValType() = delete;
   ~ValType();
@@ -267,7 +271,7 @@ class GlobalType;
 class TableType;
 class MemoryType;
 
-class ExternType {
+class WASM_C_API ExternType {
 public:
   ExternType() = delete;
   ~ExternType();
@@ -291,7 +295,7 @@ public:
 
 // Function Types
 
-class FuncType : public ExternType {
+class WASM_C_API FuncType : public ExternType {
 public:
   FuncType() = delete;
   ~FuncType();
@@ -310,7 +314,7 @@ public:
 
 // Global Types
 
-class GlobalType : public ExternType {
+class WASM_C_API GlobalType : public ExternType {
 public:
   GlobalType() = delete;
   ~GlobalType();
@@ -325,7 +329,7 @@ public:
 
 // Table Types
 
-class TableType : public ExternType {
+class WASM_C_API TableType : public ExternType {
 public:
   TableType() = delete;
   ~TableType();
@@ -340,7 +344,7 @@ public:
 
 // Memory Types
 
-class MemoryType : public ExternType {
+class WASM_C_API MemoryType : public ExternType {
 public:
   MemoryType() = delete;
   ~MemoryType();
@@ -356,7 +360,7 @@ public:
 
 using Name = vec<byte_t>;
 
-class ImportType {
+class WASM_C_API ImportType {
 public:
   ImportType() = delete;
   ~ImportType();
@@ -374,7 +378,7 @@ public:
 
 // Export Types
 
-class ExportType {
+class WASM_C_API ExportType {
 public:
   ExportType() = delete;
   ~ExportType();
@@ -393,7 +397,7 @@ public:
 
 // References
 
-class Ref {
+class WASM_C_API Ref {
 public:
   Ref() = delete;
   ~Ref();
@@ -531,7 +535,7 @@ using Message = vec<byte_t>;  // null terminated
 
 class Instance;
 
-class Frame {
+class WASM_C_API Frame {
 public:
   Frame() = delete;
   ~Frame();
@@ -545,7 +549,7 @@ public:
   auto module_offset() const -> size_t;
 };
 
-class Trap : public Ref {
+class WASM_C_API Trap : public Ref {
 public:
   Trap() = delete;
   ~Trap();
@@ -562,7 +566,7 @@ public:
 // Shared objects
 
 template<class T>
-class Shared {
+class WASM_C_API Shared {
 public:
   Shared() = delete;
   ~Shared();
@@ -572,7 +576,7 @@ public:
 
 // Modules
 
-class Module : public Ref {
+class WASM_C_API Module : public Ref {
 public:
   Module() = delete;
   ~Module();
@@ -594,7 +598,7 @@ public:
 
 // Foreign Objects
 
-class Foreign : public Ref {
+class WASM_C_API Foreign : public Ref {
 public:
   Foreign() = delete;
   ~Foreign();
@@ -611,7 +615,7 @@ class Global;
 class Table;
 class Memory;
 
-class Extern : public Ref {
+class WASM_C_API Extern : public Ref {
 public:
   Extern() = delete;
   ~Extern();
@@ -635,7 +639,7 @@ public:
 
 // Function Instances
 
-class Func : public Extern {
+class WASM_C_API Func : public Extern {
 public:
   Func() = delete;
   ~Func();
@@ -658,7 +662,7 @@ public:
 
 // Global Instances
 
-class Global : public Extern {
+class WASM_C_API Global : public Extern {
 public:
   Global() = delete;
   ~Global();
@@ -674,7 +678,7 @@ public:
 
 // Table Instances
 
-class Table : public Extern {
+class WASM_C_API Table : public Extern {
 public:
   Table() = delete;
   ~Table();
@@ -695,7 +699,7 @@ public:
 
 // Memory Instances
 
-class Memory : public Extern {
+class WASM_C_API Memory : public Extern {
 public:
   Memory() = delete;
   ~Memory();
@@ -717,7 +721,7 @@ public:
 
 // Module Instances
 
-class Instance : public Ref {
+class WASM_C_API Instance : public Ref {
 public:
   Instance() = delete;
   ~Instance();


### PR DESCRIPTION
This allows implementations to define `WASM_C_API=__declspec(dllexport)`, and users to define `WASM_C_API=__declspec(dllimport)`, which is the most concise way to import and export from a DLL on Windows.