### PR TITLE
Explicitly number wasm_valkind_t to leave space for new numeric types

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -163,12 +163,12 @@ static const uint32_t wasm_limits_max_default = 0xffffffff;
 WASM_DECLARE_TYPE(valtype)
 
 typedef enum wasm_valkind_t {
-  WASM_I32,
-  WASM_I64,
-  WASM_F32,
-  WASM_F64,
-  WASM_ANYREF,
-  WASM_FUNCREF
+  WASM_I32 = 0,
+  WASM_I64 = 1,
+  WASM_F32 = 2,
+  WASM_F64 = 3,
+  WASM_ANYREF = 128+0,
+  WASM_FUNCREF = 128+1
 } wasm_valkind_t;
 
 own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -288,7 +288,14 @@ struct Limits {
 
 // Value Types
 
-enum ValKind { I32, I64, F32, F64, ANYREF, FUNCREF };
+enum ValKind {
+  I32 = 0,
+  I64 = 1,
+  F32 = 2,
+  F64 = 3,
+  ANYREF = 128+0,
+  FUNCREF = 128+1
+};
 
 inline bool is_num(ValKind k) { return k < ANYREF; }
 inline bool is_ref(ValKind k) { return k >= ANYREF; }

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -548,14 +548,12 @@ struct ValTypeImpl {
 
 template<> struct implement<ValType> { using type = ValTypeImpl; };
 
-ValTypeImpl* valtypes[] = {
-  new ValTypeImpl(I32),
-  new ValTypeImpl(I64),
-  new ValTypeImpl(F32),
-  new ValTypeImpl(F64),
-  new ValTypeImpl(ANYREF),
-  new ValTypeImpl(FUNCREF),
-};
+ValTypeImpl* valtype_i32 = new ValTypeImpl(I32);
+ValTypeImpl* valtype_i64 = new ValTypeImpl(I64);
+ValTypeImpl* valtype_f32 = new ValTypeImpl(F32);
+ValTypeImpl* valtype_f64 = new ValTypeImpl(F64);
+ValTypeImpl* valtype_anyref = new ValTypeImpl(ANYREF);
+ValTypeImpl* valtype_funcref = new ValTypeImpl(FUNCREF);
 
 
 ValType::~ValType() {
@@ -565,7 +563,19 @@ ValType::~ValType() {
 void ValType::operator delete(void*) {}
 
 auto ValType::make(ValKind k) -> own<ValType*> {
-  auto result = seal<ValType>(valtypes[k]);
+  ValTypeImpl* valtype;
+  switch (k) {
+    case I32: valtype = valtype_i32; break;
+    case I64: valtype = valtype_i64; break;
+    case F32: valtype = valtype_f32; break;
+    case F64: valtype = valtype_f64; break;
+    case ANYREF: valtype = valtype_anyref; break;
+    case FUNCREF: valtype = valtype_funcref; break;
+    default:
+      // TODO(wasm+): support new value types
+      assert(false);
+  };
+  auto result = seal<ValType>(valtype);
   stats.make(Stats::VALTYPE, result);
   return own<ValType*>(result);
 }


### PR DESCRIPTION
This should allow adding new numeric value kinds in a backward compatible way, to the extent that an API client isn't trying to handle every case of `wasm_valkind_t`.