### PR TITLE
Fix life times of host info

### DIFF
--- a/example/finalize.c
+++ b/example/finalize.c
@@ -9,23 +9,21 @@
 
 const int iterations = 100000;
 
+int live_count = 0;
+
 void finalize(void* data) {
   int i = (int)data;
   if (i % (iterations / 10) == 0) printf("Finalizing #%d...\n", i);
+  --live_count;
 }
 
-int main(int argc, const char* argv[]) {
-  // Initialize.
-  printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new();
-  wasm_store_t* store = wasm_store_new(engine);
-
+void run_in_store(wasm_store_t* store) {
   // Load binary.
   printf("Loading binary...\n");
   FILE* file = fopen("finalize.wasm", "r");
   if (!file) {
     printf("> Error loading module!\n");
-    return 1;
+    exit(1);
   }
   fseek(file, 0L, SEEK_END);
   size_t file_size = ftell(file);
@@ -34,7 +32,7 @@ int main(int argc, const char* argv[]) {
   wasm_byte_vec_new_uninitialized(&binary, file_size);
   if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
-    return 1;
+    exit(1);
   }
   fclose(file);
 
@@ -43,7 +41,7 @@ int main(int argc, const char* argv[]) {
   own wasm_module_t* module = wasm_module_new(store, &binary);
   if (!module) {
     printf("> Error compiling module!\n");
-    return 1;
+    exit(1);
   }
 
   wasm_byte_vec_delete(&binary);
@@ -55,18 +53,53 @@ int main(int argc, const char* argv[]) {
     own wasm_instance_t* instance = wasm_instance_new(store, module, NULL);
     if (!instance) {
       printf("> Error instantiating module %d!\n", i);
-      return 1;
+      exit(1);
     }
     void* data = (void*)(intptr_t)i;
     wasm_instance_set_host_info_with_finalizer(instance, data, &finalize);
     wasm_instance_delete(instance);
+    ++live_count;
   }
 
   wasm_module_delete(module);
+}
+
+int main(int argc, const char* argv[]) {
+  // Initialize.
+  printf("Initializing...\n");
+  wasm_engine_t* engine = wasm_engine_new();
+
+  printf("Live count %d\n", live_count);
+  printf("Creating store 1...\n");
+  wasm_store_t* store1 = wasm_store_new(engine);
+
+  printf("Running in store 1...\n");
+  run_in_store(store1);
+  printf("Live count %d\n", live_count);
+
+  printf("Creating store 2...\n");
+  wasm_store_t* store2 = wasm_store_new(engine);
+
+  printf("Running in store 2...\n");
+  run_in_store(store2);
+  printf("Live count %d\n", live_count);
+
+  printf("Deleting store 2...\n");
+  wasm_store_delete(store2);
+  printf("Live count %d\n", live_count);
+
+  printf("Running in store 1...\n");
+  run_in_store(store1);
+  printf("Live count %d\n", live_count);
+
+  printf("Deleting store 1...\n");
+  wasm_store_delete(store1);
+  printf("Live count %d\n", live_count);
+
+  assert(live_count == 0);
 
   // Shut down.
   printf("Shutting down...\n");
-  wasm_store_delete(store);
   wasm_engine_delete(engine);
 
   // All done.

--- a/example/finalize.cc
+++ b/example/finalize.cc
@@ -9,20 +9,17 @@
 
 const int iterations = 100000;
 
+int live_count = 0;
+
 void finalize(void* data) {
   intptr_t i = reinterpret_cast<intptr_t>(data);
   if (i % (iterations / 10) == 0) {
     std::cout << "Finalizing #" << i << "..." << std::endl;
   }
+  --live_count;
 }
 
-void run() {
-  // Initialize.
-  std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make();
-  auto store_ = wasm::Store::make(engine.get());
-  auto store = store_.get();
-
+void run_in_store(wasm::Store* store) {
   // Load binary.
   std::cout << "Loading binary..." << std::endl;
   std::ifstream file("finalize.wasm");
@@ -52,9 +49,10 @@ void run() {
     auto instance = wasm::Instance::make(store, module.get(), nullptr);
     if (!instance) {
       std::cout << "> Error instantiating module " << i << "!" << std::endl;
-    exit(1);
+      exit(1);
     }
     instance->set_host_info(reinterpret_cast<void*>(i), &finalize);
+    ++live_count;
   }
 
   // Shut down.
@@ -62,8 +60,43 @@ void run() {
 }
 
 
+void run() {
+  // Initialize.
+  std::cout << "Initializing..." << std::endl;
+  auto engine = wasm::Engine::make();
+
+  std::cout << "Live count " << live_count << std::endl;
+  std::cout << "Creating store 1..." << std::endl;
+  auto store1 = wasm::Store::make(engine.get());
+
+  std::cout << "Running in store 1..." << std::endl;
+  run_in_store(store1.get());
+  std::cout << "Live count " << live_count << std::endl;
+
+  {
+    std::cout << "Creating store 2..." << std::endl;
+    auto store2 = wasm::Store::make(engine.get());
+
+    std::cout << "Running in store 2..." << std::endl;
+    run_in_store(store2.get());
+    std::cout << "Live count " << live_count << std::endl;
+
+    std::cout << "Deleting store 2..." << std::endl;
+    std::cout << "Live count " << live_count << std::endl;
+  }
+
+  std::cout << "Running in store 1..." << std::endl;
+  run_in_store(store1.get());
+  std::cout << "Live count " << live_count << std::endl;
+
+  std::cout << "Deleting store 1..." << std::endl;
+}
+
+
 int main(int argc, const char* argv[]) {
   run();
+  std::cout << "Live count " << live_count << std::endl;
+  assert(live_count == 0);
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/src/wasm-v8-lowlevel.hh
+++ b/src/wasm-v8-lowlevel.hh
@@ -20,6 +20,9 @@ auto object_is_error(v8::Local<v8::Object>) -> bool;
 auto foreign_new(v8::Isolate*, void*) -> v8::Local<v8::Value>;
 auto foreign_get(v8::Local<v8::Value>) -> void*;
 
+auto managed_new(v8::Isolate*, void*, void (*)(void*)) -> v8::Local<v8::Value>;
+auto managed_get(v8::Local<v8::Value>) -> void*;
+
 enum val_kind_t { I32, I64, F32, F64, ANYREF = 128, FUNCREF };
 auto func_type_param_arity(v8::Local<v8::Object> global) -> uint32_t;
 auto func_type_result_arity(v8::Local<v8::Object> global) -> uint32_t;

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -1115,10 +1115,6 @@ public:
   void set_host_info(void* info, void (*finalizer)(void*)) {
     v8::HandleScope handle_scope(isolate());
     auto store = this->store();
-
-    // V8 attaches finalizers to handles instead of objects, and such handles
-    // cannot be reused after the finalizer has been invoked.
-    // So we need to create them separately from the pool.
     auto managed = wasm_v8::managed_new(store->isolate(), info, finalizer);
     v8::Local<v8::Value> args[] = { v8_object(), managed };
     auto maybe_result = store->v8_function(V8_F_WEAKMAP_SET)->Call(

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -1109,9 +1109,7 @@ public:
     auto maybe_result = store->v8_function(V8_F_WEAKMAP_GET)->Call(
       store->context(), store->host_data_map(), 1, args);
     if (maybe_result.IsEmpty()) return nullptr;
-
-    auto data = wasm_v8::foreign_get(maybe_result.ToLocalChecked());
-    return reinterpret_cast<HostData*>(data)->info;
+    return wasm_v8::managed_get(maybe_result.ToLocalChecked());
   }
 
   void set_host_info(void* info, void (*finalizer)(void*)) {
@@ -1121,32 +1119,11 @@ public:
     // V8 attaches finalizers to handles instead of objects, and such handles
     // cannot be reused after the finalizer has been invoked.
     // So we need to create them separately from the pool.
-    auto data = new HostData(store->isolate(), v8_object(), info, finalizer);
-    data->handle.template SetWeak<HostData>(
-      data, &v8_finalizer, v8::WeakCallbackType::kParameter);
-    auto foreign = wasm_v8::foreign_new(store->isolate(), data);
-    v8::Local<v8::Value> args[] = { v8_object(), foreign };
+    auto managed = wasm_v8::managed_new(store->isolate(), info, finalizer);
+    v8::Local<v8::Value> args[] = { v8_object(), managed };
     auto maybe_result = store->v8_function(V8_F_WEAKMAP_SET)->Call(
       store->context(), store->host_data_map(), 2, args);
     if (maybe_result.IsEmpty()) return;
-  }
-
-private:
-  struct HostData {
-    HostData(
-      v8::Isolate* isolate, v8::Local<v8::Object> object,
-      void* info, void (*finalizer)(void*)) :
-      handle(isolate, object), info(info), finalizer(finalizer) {}
-    v8::Persistent<v8::Object> handle;
-    void* info;
-    void (*finalizer)(void*);
-  };
-
-  static void v8_finalizer(const v8::WeakCallbackInfo<HostData>& info) {
-    auto data = info.GetParameter();
-    data->handle.Reset();  // Must reset weak handle before deleting it!
-    if (data->finalizer) (*data->finalizer)(data->info);
-    delete data;
   }
 };
 


### PR DESCRIPTION
Use V8's Managed values to represent finalized host data. This way, it gets properly freed when the associated store is deleted.

Fixes #74.

@PiotrSikora, FYI.