### PR TITLE
Set the rhs vec to invalid_size after a move

### DIFF
--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -82,6 +82,7 @@ public:
   }
 
   auto release() -> T* {
+    size_ = invalid_size;
     return data_.release();
   }
 
@@ -95,6 +96,7 @@ public:
     free_data();
     size_ = that.size_;
     data_.reset(that.data_.release());
+    that.size_ = invalid_size;
   }
 
   auto operator=(vec&& that) -> vec& {

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -57,7 +57,9 @@ class vec {
 public:
   using elem_type = T;
 
-  vec(vec<T>&& that) : vec(that.size_, that.data_.release()) {}
+  vec(vec<T>&& that) : vec(that.size_, that.data_.release()) {
+    that.size_ = invalid_size;
+  }
 
   ~vec() {
     free_data();


### PR DESCRIPTION
Operations such as `operator bool()` check for `size != invalid_size`, so seems like this should be the state after it has been moved from.