### PR TITLE
Add WASI_API macro to each API entry point

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -14,6 +14,12 @@
 extern "C" {
 #endif
 
+// Tag used on all API entry points.  Can be set by the build environment to
+// handle such things as settings symbol visibility.
+#ifndef WASM_API
+#define WASM_API
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // Auxiliaries
 
@@ -60,8 +66,7 @@ typedef double float64_t;
 
 #define WASM_DECLARE_OWN(name) \
   typedef struct wasm_##name##_t wasm_##name##_t; \
-  \
-  void wasm_##name##_delete(own wasm_##name##_t*);
+  WASM_API void wasm_##name##_delete(own wasm_##name##_t*);
 
 
 // Vectors
@@ -72,15 +77,15 @@ typedef double float64_t;
     wasm_##name##_t ptr_or_none* data; \
   } wasm_##name##_vec_t; \
   \
-  void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
-  void wasm_##name##_vec_new_uninitialized( \
+  WASM_API void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
+  WASM_API void wasm_##name##_vec_new_uninitialized( \
     own wasm_##name##_vec_t* out, size_t); \
-  void wasm_##name##_vec_new( \
+  WASM_API void wasm_##name##_vec_new( \
     own wasm_##name##_vec_t* out, \
     size_t, own wasm_##name##_t ptr_or_none const[]); \
-  void wasm_##name##_vec_copy( \
+  WASM_API void wasm_##name##_vec_copy( \
     own wasm_##name##_vec_t* out, const wasm_##name##_vec_t*); \
-  void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
+  WASM_API void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
 
 
 // Byte vectors
@@ -120,15 +125,15 @@ own wasm_config_t* wasm_config_new();
 
 WASM_DECLARE_OWN(engine)
 
-own wasm_engine_t* wasm_engine_new();
-own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
+WASM_API own wasm_engine_t* wasm_engine_new();
+WASM_API own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
 
 // Store
 
 WASM_DECLARE_OWN(store)
 
-own wasm_store_t* wasm_store_new(wasm_engine_t*);
+WASM_API own wasm_store_t* wasm_store_new(wasm_engine_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -173,9 +178,9 @@ enum wasm_valkind_enum {
   WASM_FUNCREF,
 };
 
-own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
+WASM_API own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
 
-wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
+WASM_API wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
 
 static inline bool wasm_valkind_is_num(wasm_valkind_t k) {
   return k < WASM_ANYREF;
@@ -196,42 +201,42 @@ static inline bool wasm_valtype_is_ref(const wasm_valtype_t* t) {
 
 WASM_DECLARE_TYPE(functype)
 
-own wasm_functype_t* wasm_functype_new(
+WASM_API own wasm_functype_t* wasm_functype_new(
   own wasm_valtype_vec_t* params, own wasm_valtype_vec_t* results);
 
-const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
-const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
+WASM_API const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
+WASM_API const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
 
 
 // Global Types
 
 WASM_DECLARE_TYPE(globaltype)
 
-own wasm_globaltype_t* wasm_globaltype_new(
+WASM_API own wasm_globaltype_t* wasm_globaltype_new(
   own wasm_valtype_t*, wasm_mutability_t);
 
-const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
-wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
+WASM_API const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
+WASM_API wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
 
 
 // Table Types
 
 WASM_DECLARE_TYPE(tabletype)
 
-own wasm_tabletype_t* wasm_tabletype_new(
+WASM_API own wasm_tabletype_t* wasm_tabletype_new(
   own wasm_valtype_t*, const wasm_limits_t*);
 
-const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
-const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
+WASM_API const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
+WASM_API const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
 
 
 // Memory Types
 
 WASM_DECLARE_TYPE(memorytype)
 
-own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
+WASM_API own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
 
-const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
+WASM_API const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
 
 
 // Extern Types
@@ -246,50 +251,50 @@ enum wasm_externkind_enum {
   WASM_EXTERN_MEMORY,
 };
 
-wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
+WASM_API wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
 
-wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
-wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
-wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
-wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
+WASM_API wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
+WASM_API wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
+WASM_API wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
+WASM_API wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
 
-wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
-wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
-wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
-wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
+WASM_API wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
+WASM_API wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
+WASM_API wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
+WASM_API wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
 
-const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
-const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
-const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
-const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
+WASM_API const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
+WASM_API const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
+WASM_API const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
+WASM_API const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
 
-const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
-const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
-const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
-const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
+WASM_API const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
+WASM_API const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
+WASM_API const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
+WASM_API const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
 
 
 // Import Types
 
 WASM_DECLARE_TYPE(importtype)
 
-own wasm_importtype_t* wasm_importtype_new(
+WASM_API own wasm_importtype_t* wasm_importtype_new(
   own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
 
-const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
-const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
-const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
+WASM_API const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
+WASM_API const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
+WASM_API const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
 
 
 // Export Types
 
 WASM_DECLARE_TYPE(exporttype)
 
-own wasm_exporttype_t* wasm_exporttype_new(
+WASM_API own wasm_exporttype_t* wasm_exporttype_new(
   own wasm_name_t*, own wasm_externtype_t*);
 
-const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
-const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
+WASM_API const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
+WASM_API const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -310,8 +315,8 @@ typedef struct wasm_val_t {
   } of;
 } wasm_val_t;
 
-void wasm_val_delete(own wasm_val_t* v);
-void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
+WASM_API void wasm_val_delete(own wasm_val_t* v);
+WASM_API void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
 
 WASM_DECLARE_VEC(val, )
 
@@ -321,28 +326,28 @@ WASM_DECLARE_VEC(val, )
 #define WASM_DECLARE_REF_BASE(name) \
   WASM_DECLARE_OWN(name) \
   \
-  own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
-  bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
+  WASM_API own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
+  WASM_API bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
   \
-  void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
-  void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
-  void wasm_##name##_set_host_info_with_finalizer( \
+  WASM_API void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
+  WASM_API void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
+  WASM_API void wasm_##name##_set_host_info_with_finalizer( \
     wasm_##name##_t*, void*, void (*)(void*));
 
 #define WASM_DECLARE_REF(name) \
   WASM_DECLARE_REF_BASE(name) \
   \
-  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
-  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
-  const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
-  const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
+  WASM_API wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
+  WASM_API wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
+  WASM_API const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
+  WASM_API const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
 
 #define WASM_DECLARE_SHARABLE_REF(name) \
   WASM_DECLARE_REF(name) \
   WASM_DECLARE_OWN(shared_##name) \
   \
-  own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
-  own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
+  WASM_API own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
+  WASM_API own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
 
 
 WASM_DECLARE_REF_BASE(ref)
@@ -354,10 +359,10 @@ WASM_DECLARE_OWN(frame)
 WASM_DECLARE_VEC(frame, *)
 own wasm_frame_t* wasm_frame_copy(const wasm_frame_t*);
 
-struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
-uint32_t wasm_frame_func_index(const wasm_frame_t*);
-size_t wasm_frame_func_offset(const wasm_frame_t*);
-size_t wasm_frame_module_offset(const wasm_frame_t*);
+WASM_API struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
+WASM_API uint32_t wasm_frame_func_index(const wasm_frame_t*);
+WASM_API size_t wasm_frame_func_offset(const wasm_frame_t*);
+WASM_API size_t wasm_frame_module_offset(const wasm_frame_t*);
 
 
 // Traps
@@ -366,34 +371,34 @@ typedef wasm_name_t wasm_message_t;  // null terminated
 
 WASM_DECLARE_REF(trap)
 
-own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
+WASM_API own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
 
-void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
-own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
-void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
+WASM_API void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
+WASM_API own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
+WASM_API void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
 
 
 // Foreign Objects
 
 WASM_DECLARE_REF(foreign)
 
-own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
+WASM_API own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
 
 
 // Modules
 
 WASM_DECLARE_SHARABLE_REF(module)
 
-own wasm_module_t* wasm_module_new(
+WASM_API own wasm_module_t* wasm_module_new(
   wasm_store_t*, const wasm_byte_vec_t* binary);
 
-bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
+WASM_API bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
 
-void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
-void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
+WASM_API void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
+WASM_API void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 
-void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
-own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
+WASM_API void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
+WASM_API own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
 
 
 // Function Instances
@@ -405,17 +410,17 @@ typedef own wasm_trap_t* (*wasm_func_callback_t)(
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
   void* env, const wasm_val_t args[], wasm_val_t results[]);
 
-own wasm_func_t* wasm_func_new(
+WASM_API own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
-own wasm_func_t* wasm_func_new_with_env(
+WASM_API own wasm_func_t* wasm_func_new_with_env(
   wasm_store_t*, const wasm_functype_t* type, wasm_func_callback_with_env_t,
   void* env, void (*finalizer)(void*));
 
-own wasm_functype_t* wasm_func_type(const wasm_func_t*);
-size_t wasm_func_param_arity(const wasm_func_t*);
-size_t wasm_func_result_arity(const wasm_func_t*);
+WASM_API own wasm_functype_t* wasm_func_type(const wasm_func_t*);
+WASM_API size_t wasm_func_param_arity(const wasm_func_t*);
+WASM_API size_t wasm_func_result_arity(const wasm_func_t*);
 
-own wasm_trap_t* wasm_func_call(
+WASM_API own wasm_trap_t* wasm_func_call(
   const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
 
 
@@ -423,13 +428,13 @@ own wasm_trap_t* wasm_func_call(
 
 WASM_DECLARE_REF(global)
 
-own wasm_global_t* wasm_global_new(
+WASM_API own wasm_global_t* wasm_global_new(
   wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
 
-own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
+WASM_API own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
-void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
-void wasm_global_set(wasm_global_t*, const wasm_val_t*);
+WASM_API void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
+WASM_API void wasm_global_set(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances
@@ -438,16 +443,16 @@ WASM_DECLARE_REF(table)
 
 typedef uint32_t wasm_table_size_t;
 
-own wasm_table_t* wasm_table_new(
+WASM_API own wasm_table_t* wasm_table_new(
   wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
 
-own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
+WASM_API own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
-own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
+WASM_API own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
 bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
 
-wasm_table_size_t wasm_table_size(const wasm_table_t*);
-bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
+WASM_API wasm_table_size_t wasm_table_size(const wasm_table_t*);
+WASM_API bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
 
 
 // Memory Instances
@@ -458,15 +463,15 @@ typedef uint32_t wasm_memory_pages_t;
 
 static const size_t MEMORY_PAGE_SIZE = 0x10000;
 
-own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
+WASM_API own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
 
-own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
+WASM_API own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
 
-byte_t* wasm_memory_data(wasm_memory_t*);
-size_t wasm_memory_data_size(const wasm_memory_t*);
+WASM_API byte_t* wasm_memory_data(wasm_memory_t*);
+WASM_API size_t wasm_memory_data_size(const wasm_memory_t*);
 
-wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
-bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
+WASM_API wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
+WASM_API bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 
 
 // Externals
@@ -474,40 +479,40 @@ bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 WASM_DECLARE_REF(extern)
 WASM_DECLARE_VEC(extern, *)
 
-wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
-own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
+WASM_API wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
+WASM_API own wasm_externtype_t* wasm_extern_type(const wasm_extern_t*);
 
-wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
-wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
-wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
-wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
+WASM_API wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
+WASM_API wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
+WASM_API wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
+WASM_API wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
 
-wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
-wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
-wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
-wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
+WASM_API wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
+WASM_API wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
+WASM_API wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
+WASM_API wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
 
-const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
-const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
-const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
-const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
+WASM_API const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
+WASM_API const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
+WASM_API const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
+WASM_API const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
 
-const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
-const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
-const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
-const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
+WASM_API const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
+WASM_API const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
+WASM_API const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
+WASM_API const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
 
 
 // Module Instances
 
 WASM_DECLARE_REF(instance)
 
-own wasm_instance_t* wasm_instance_new(
+WASM_API own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
   own wasm_trap_t**
 );
 
-void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
+WASM_API void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
 
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This allows the build system do think such as:
  -DWASM_API=__attribute__((visibility("default")))

An alternative to this would be do something more explicit and
include the macros in the source like in binaryen:

 #if defined(_MSC_VER) && !defined(BUILD_STATIC_LIBRARY)
 efine BINARYEN_API __declspec(dllexport)
 #else

Or we could try to do it without tagging each entry point using:

 #pragma GCC visibility push
 #pragma GCC visibility pop

But these is less portable. For example I'm not sure if msvc supports
this kind of things.