### PR TITLE
Add a Chromium .clang-format file, and apply it

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Chromium

--- a/example/callback.c
+++ b/example/callback.c
@@ -1,7 +1,7 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
@@ -34,9 +34,7 @@ void wasm_val_print(wasm_val_t val) {
 }
 
 // A function to be called from Wasm code.
-own wasm_trap_t* print_callback(
-  const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* print_callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("Calling back...\n> ");
   wasm_val_print(args[0]);
   printf("\n");
@@ -45,11 +43,10 @@ own wasm_trap_t* print_callback(
   return NULL;
 }
 
-
 // A function closure.
-own wasm_trap_t* closure_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* closure_callback(void* env,
+                                  const wasm_val_t args[],
+                                  wasm_val_t results[]) {
   int i = *(int*)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
@@ -58,7 +55,6 @@ own wasm_trap_t* closure_callback(
   results[0].of.i32 = (int32_t)i;
   return NULL;
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -96,23 +92,26 @@ int main(int argc, const char* argv[]) {
 
   // Create external print functions.
   printf("Creating callback...\n");
-  own wasm_functype_t* print_type = wasm_functype_new_1_1(wasm_valtype_new_i32(), wasm_valtype_new_i32());
-  own wasm_func_t* print_func = wasm_func_new(store, print_type, print_callback);
+  own wasm_functype_t* print_type =
+      wasm_functype_new_1_1(wasm_valtype_new_i32(), wasm_valtype_new_i32());
+  own wasm_func_t* print_func =
+      wasm_func_new(store, print_type, print_callback);
 
   int i = 42;
-  own wasm_functype_t* closure_type = wasm_functype_new_0_1(wasm_valtype_new_i32());
-  own wasm_func_t* closure_func = wasm_func_new_with_env(store, closure_type, closure_callback, &i, NULL);
+  own wasm_functype_t* closure_type =
+      wasm_functype_new_0_1(wasm_valtype_new_i32());
+  own wasm_func_t* closure_func =
+      wasm_func_new_with_env(store, closure_type, closure_callback, &i, NULL);
 
   wasm_functype_delete(print_type);
   wasm_functype_delete(closure_type);
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
-    wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
-  };
+  const wasm_extern_t* imports[] = {wasm_func_as_extern(print_func),
+                                    wasm_func_as_extern(closure_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/callback.cc
+++ b/example/callback.cc
@@ -1,8 +1,8 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
@@ -34,26 +34,22 @@ auto operator<<(std::ostream& out, const wasm::Val& val) -> std::ostream& {
 }
 
 // A function to be called from Wasm code.
-auto print_callback(
-  const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto print_callback(const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl << "> " << args[0] << std::endl;
   results[0] = args[0].copy();
   return nullptr;
 }
 
-
 // A function closure.
-auto closure_callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto closure_callback(void* env, const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   auto i = *reinterpret_cast<int*>(env);
   std::cout << "Calling back closure..." << std::endl;
   std::cout << "> " << i << std::endl;
   results[0] = wasm::Val::i32(static_cast<int32_t>(i));
   return nullptr;
 }
-
 
 void run() {
   // Initialize.
@@ -87,19 +83,18 @@ void run() {
   // Create external print functions.
   std::cout << "Creating callback..." << std::endl;
   auto print_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)),
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32))
-  );
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)),
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)));
   auto print_func = wasm::Func::make(store, print_type.get(), print_callback);
 
   // Creating closure.
   std::cout << "Creating closure..." << std::endl;
   int i = 42;
   auto closure_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(),
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32))
-  );
-  auto closure_func = wasm::Func::make(store, closure_type.get(), closure_callback, &i);
+      wasm::ownvec<wasm::ValType>::make(),
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)));
+  auto closure_func =
+      wasm::Func::make(store, closure_type.get(), closure_callback, &i);
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
@@ -113,7 +108,8 @@ void run() {
   // Extract export.
   std::cout << "Extracting export..." << std::endl;
   auto exports = instance->exports();
-  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+      !exports[0]->func()) {
     std::cout << "> Error accessing export!" << std::endl;
     exit(1);
   }
@@ -136,10 +132,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -1,7 +1,7 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
@@ -13,7 +13,8 @@ int live_count = 0;
 
 void finalize(void* data) {
   int i = (int)data;
-  if (i % (iterations / 10) == 0) printf("Finalizing #%d...\n", i);
+  if (i % (iterations / 10) == 0)
+    printf("Finalizing #%d...\n", i);
   --live_count;
 }
 
@@ -49,9 +50,10 @@ void run_in_store(wasm_store_t* store) {
   // Instantiate.
   printf("Instantiating modules...\n");
   for (int i = 0; i <= iterations; ++i) {
-    if (i % (iterations / 10) == 0) printf("%d\n", i);
+    if (i % (iterations / 10) == 0)
+      printf("%d\n", i);
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, NULL, NULL);
+        wasm_instance_new(store, module, NULL, NULL);
     if (!instance) {
       printf("> Error instantiating module %d!\n", i);
       exit(1);

--- a/example/finalize.cc
+++ b/example/finalize.cc
@@ -1,11 +1,10 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
-
 
 const int iterations = 100000;
 
@@ -45,7 +44,8 @@ void run_in_store(wasm::Store* store) {
   // Instantiate.
   std::cout << "Instantiating modules..." << std::endl;
   for (int i = 0; i <= iterations; ++i) {
-    if (i % (iterations / 10) == 0) std::cout << i << std::endl;
+    if (i % (iterations / 10) == 0)
+      std::cout << i << std::endl;
     auto instance = wasm::Instance::make(store, module.get(), nullptr);
     if (!instance) {
       std::cout << "> Error instantiating module " << i << "!" << std::endl;
@@ -58,7 +58,6 @@ void run_in_store(wasm::Store* store) {
   // Shut down.
   std::cout << "Shutting down..." << std::endl;
 }
-
 
 void run() {
   // Initialize.
@@ -92,7 +91,6 @@ void run() {
   std::cout << "Deleting store 1..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Live count " << live_count << std::endl;
@@ -100,4 +98,3 @@ int main(int argc, const char* argv[]) {
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/global.c
+++ b/example/global.c
@@ -1,7 +1,7 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
@@ -23,27 +23,25 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
   return wasm_extern_as_func(exports->data[i]);
 }
 
-
-#define check(val, type, expected) \
-  if (val.of.type != expected) { \
+#define check(val, type, expected)     \
+  if (val.of.type != expected) {       \
     printf("> Error reading value\n"); \
-    exit(1); \
+    exit(1);                           \
   }
 
 #define check_global(global, type, expected) \
-  { \
-    wasm_val_t val; \
-    wasm_global_get(global, &val); \
-    check(val, type, expected); \
+  {                                          \
+    wasm_val_t val;                          \
+    wasm_global_get(global, &val);           \
+    check(val, type, expected);              \
   }
 
 #define check_call(func, type, expected) \
-  { \
-    wasm_val_t results[1]; \
+  {                                      \
+    wasm_val_t results[1];               \
     wasm_func_call(func, NULL, results); \
-    check(results[0], type, expected); \
+    check(results[0], type, expected);   \
   }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -81,27 +79,27 @@ int main(int argc, const char* argv[]) {
 
   // Create external globals.
   printf("Creating globals...\n");
-  own wasm_globaltype_t* const_f32_type = wasm_globaltype_new(
-    wasm_valtype_new(WASM_F32), WASM_CONST);
-  own wasm_globaltype_t* const_i64_type = wasm_globaltype_new(
-    wasm_valtype_new(WASM_I64), WASM_CONST);
-  own wasm_globaltype_t* var_f32_type = wasm_globaltype_new(
-    wasm_valtype_new(WASM_F32), WASM_VAR);
-  own wasm_globaltype_t* var_i64_type = wasm_globaltype_new(
-    wasm_valtype_new(WASM_I64), WASM_VAR);
+  own wasm_globaltype_t* const_f32_type =
+      wasm_globaltype_new(wasm_valtype_new(WASM_F32), WASM_CONST);
+  own wasm_globaltype_t* const_i64_type =
+      wasm_globaltype_new(wasm_valtype_new(WASM_I64), WASM_CONST);
+  own wasm_globaltype_t* var_f32_type =
+      wasm_globaltype_new(wasm_valtype_new(WASM_F32), WASM_VAR);
+  own wasm_globaltype_t* var_i64_type =
+      wasm_globaltype_new(wasm_valtype_new(WASM_I64), WASM_VAR);
 
   wasm_val_t val_f32_1 = {.kind = WASM_F32, .of = {.f32 = 1}};
   own wasm_global_t* const_f32_import =
-    wasm_global_new(store, const_f32_type, &val_f32_1);
+      wasm_global_new(store, const_f32_type, &val_f32_1);
   wasm_val_t val_i64_2 = {.kind = WASM_I64, .of = {.i64 = 2}};
   own wasm_global_t* const_i64_import =
-    wasm_global_new(store, const_i64_type, &val_i64_2);
+      wasm_global_new(store, const_i64_type, &val_i64_2);
   wasm_val_t val_f32_3 = {.kind = WASM_F32, .of = {.f32 = 3}};
   own wasm_global_t* var_f32_import =
-    wasm_global_new(store, var_f32_type, &val_f32_3);
+      wasm_global_new(store, var_f32_type, &val_f32_3);
   wasm_val_t val_i64_4 = {.kind = WASM_I64, .of = {.i64 = 4}};
   own wasm_global_t* var_i64_import =
-    wasm_global_new(store, var_i64_type, &val_i64_4);
+      wasm_global_new(store, var_i64_type, &val_i64_4);
 
   wasm_globaltype_delete(const_f32_type);
   wasm_globaltype_delete(const_i64_type);
@@ -110,14 +108,12 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
-    wasm_global_as_extern(const_f32_import),
-    wasm_global_as_extern(const_i64_import),
-    wasm_global_as_extern(var_f32_import),
-    wasm_global_as_extern(var_i64_import)
-  };
+  const wasm_extern_t* imports[] = {wasm_global_as_extern(const_f32_import),
+                                    wasm_global_as_extern(const_i64_import),
+                                    wasm_global_as_extern(var_f32_import),
+                                    wasm_global_as_extern(var_i64_import)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -195,13 +191,13 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 38);
 
   // Modify variables through calls and check again.
-  wasm_val_t args73[] = { {.kind = WASM_F32, .of = {.f32 = 73}} };
+  wasm_val_t args73[] = {{.kind = WASM_F32, .of = {.f32 = 73}}};
   wasm_func_call(set_var_f32_import, args73, NULL);
-  wasm_val_t args74[] = { {.kind = WASM_I64, .of = {.i64 = 74}} };
+  wasm_val_t args74[] = {{.kind = WASM_I64, .of = {.i64 = 74}}};
   wasm_func_call(set_var_i64_import, args74, NULL);
-  wasm_val_t args77[] = { {.kind = WASM_F32, .of = {.f32 = 77}} };
+  wasm_val_t args77[] = {{.kind = WASM_F32, .of = {.f32 = 77}}};
   wasm_func_call(set_var_f32_export, args77, NULL);
-  wasm_val_t args78[] = { {.kind = WASM_I64, .of = {.i64 = 78}} };
+  wasm_val_t args78[] = {{.kind = WASM_I64, .of = {.i64 = 78}}};
   wasm_func_call(set_var_i64_export, args78, NULL);
 
   check_global(var_f32_import, f32, 73);

--- a/example/global.cc
+++ b/example/global.cc
@@ -1,13 +1,13 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
-auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Global* {
+auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> wasm::Global* {
   if (exports.size() <= i || !exports[i]->global()) {
     std::cout << "> Error accessing global export " << i << "!" << std::endl;
     exit(1);
@@ -15,7 +15,8 @@ auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::G
   return exports[i]->global();
 }
 
-auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i) -> const wasm::Func* {
+auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> const wasm::Func* {
   if (exports.size() <= i || !exports[i]->func()) {
     std::cout << "> Error accessing function export " << i << "!" << std::endl;
     exit(1);
@@ -23,10 +24,11 @@ auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i) -> con
   return exports[i]->func();
 }
 
-template<class T, class U>
+template <class T, class U>
 void check(T actual, U expected) {
   if (actual != expected) {
-    std::cout << "> Error reading value, expected " << expected << ", got " << actual << std::endl;
+    std::cout << "> Error reading value, expected " << expected << ", got "
+              << actual << std::endl;
     exit(1);
   }
 }
@@ -47,7 +49,6 @@ void call(const wasm::Func* func, wasm::Val&& arg) {
     exit(1);
   }
 }
-
 
 void run() {
   // Initialize.
@@ -80,25 +81,27 @@ void run() {
 
   // Create external globals.
   std::cout << "Creating globals..." << std::endl;
-  auto const_f32_type = wasm::GlobalType::make(
-    wasm::ValType::make(wasm::F32), wasm::CONST);
-  auto const_i64_type = wasm::GlobalType::make(
-    wasm::ValType::make(wasm::I64), wasm::CONST);
-  auto var_f32_type = wasm::GlobalType::make(
-    wasm::ValType::make(wasm::F32), wasm::VAR);
-  auto var_i64_type = wasm::GlobalType::make(
-    wasm::ValType::make(wasm::I64), wasm::VAR);
-  auto const_f32_import = wasm::Global::make(store, const_f32_type.get(), wasm::Val::f32(1));
-  auto const_i64_import = wasm::Global::make(store, const_i64_type.get(), wasm::Val::i64(2));
-  auto var_f32_import = wasm::Global::make(store, var_f32_type.get(), wasm::Val::f32(3));
-  auto var_i64_import = wasm::Global::make(store, var_i64_type.get(), wasm::Val::i64(4));
+  auto const_f32_type =
+      wasm::GlobalType::make(wasm::ValType::make(wasm::F32), wasm::CONST);
+  auto const_i64_type =
+      wasm::GlobalType::make(wasm::ValType::make(wasm::I64), wasm::CONST);
+  auto var_f32_type =
+      wasm::GlobalType::make(wasm::ValType::make(wasm::F32), wasm::VAR);
+  auto var_i64_type =
+      wasm::GlobalType::make(wasm::ValType::make(wasm::I64), wasm::VAR);
+  auto const_f32_import =
+      wasm::Global::make(store, const_f32_type.get(), wasm::Val::f32(1));
+  auto const_i64_import =
+      wasm::Global::make(store, const_i64_type.get(), wasm::Val::i64(2));
+  auto var_f32_import =
+      wasm::Global::make(store, var_f32_type.get(), wasm::Val::f32(3));
+  auto var_i64_import =
+      wasm::Global::make(store, var_i64_type.get(), wasm::Val::i64(4));
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {
-    const_f32_import.get(), const_i64_import.get(),
-    var_f32_import.get(), var_i64_import.get()
-  };
+  wasm::Extern* imports[] = {const_f32_import.get(), const_i64_import.get(),
+                             var_f32_import.get(), var_i64_import.get()};
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -187,10 +190,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/hello.c
+++ b/example/hello.c
@@ -1,21 +1,18 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
 
 // A function to be called from Wasm code.
-own wasm_trap_t* hello_callback(
-  const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -55,15 +52,15 @@ int main(int argc, const char* argv[]) {
   printf("Creating callback...\n");
   own wasm_functype_t* hello_type = wasm_functype_new_0_0();
   own wasm_func_t* hello_func =
-    wasm_func_new(store, hello_type, hello_callback);
+      wasm_func_new(store, hello_type, hello_callback);
 
   wasm_functype_delete(hello_type);
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  const wasm_extern_t* imports[] = {wasm_func_as_extern(hello_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -1,21 +1,18 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
 // A function to be called from Wasm code.
-auto hello_callback(
-  const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto hello_callback(const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> Hello world!" << std::endl;
   return nullptr;
 }
-
 
 void run() {
   // Initialize.
@@ -48,9 +45,8 @@ void run() {
 
   // Create external print functions.
   std::cout << "Creating callback..." << std::endl;
-  auto hello_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(), wasm::ownvec<wasm::ValType>::make()
-  );
+  auto hello_type = wasm::FuncType::make(wasm::ownvec<wasm::ValType>::make(),
+                                         wasm::ownvec<wasm::ValType>::make());
   auto hello_func = wasm::Func::make(store, hello_type.get(), hello_callback);
 
   // Instantiate.
@@ -65,7 +61,8 @@ void run() {
   // Extract export.
   std::cout << "Extracting export..." << std::endl;
   auto exports = instance->exports();
-  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+      !exports[0]->func()) {
     std::cout << "> Error accessing export!" << std::endl;
     exit(1);
   }
@@ -82,10 +79,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/hostref.c
+++ b/example/hostref.c
@@ -1,24 +1,20 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
 
-
 // A function to be called from Wasm code.
-own wasm_trap_t* callback(
-  const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("Calling back...\n> ");
   printf("> %p\n",
-    args[0].of.ref ? wasm_ref_get_host_info(args[0].of.ref) : NULL);
+         args[0].of.ref ? wasm_ref_get_host_info(args[0].of.ref) : NULL);
   wasm_val_copy(&results[0], &args[0]);
   return NULL;
 }
-
 
 wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
   if (exports->size <= i || !wasm_extern_as_func(exports->data[i])) {
@@ -44,9 +40,9 @@ wasm_table_t* get_export_table(const wasm_extern_vec_t* exports, size_t i) {
   return wasm_extern_as_table(exports->data[i]);
 }
 
-
 own wasm_ref_t* call_v_r(const wasm_func_t* func) {
-  printf("call_v_r... "); fflush(stdout);
+  printf("call_v_r... ");
+  fflush(stdout);
   wasm_val_t results[1];
   if (wasm_func_call(func, NULL, results)) {
     printf("> Error calling function!\n");
@@ -57,7 +53,8 @@ own wasm_ref_t* call_v_r(const wasm_func_t* func) {
 }
 
 void call_r_v(const wasm_func_t* func, wasm_ref_t* ref) {
-  printf("call_r_v... "); fflush(stdout);
+  printf("call_r_v... ");
+  fflush(stdout);
   wasm_val_t args[1];
   args[0].kind = WASM_ANYREF;
   args[0].of.ref = ref;
@@ -69,7 +66,8 @@ void call_r_v(const wasm_func_t* func, wasm_ref_t* ref) {
 }
 
 own wasm_ref_t* call_r_r(const wasm_func_t* func, wasm_ref_t* ref) {
-  printf("call_r_r... "); fflush(stdout);
+  printf("call_r_r... ");
+  fflush(stdout);
   wasm_val_t args[1];
   args[0].kind = WASM_ANYREF;
   args[0].of.ref = ref;
@@ -83,7 +81,8 @@ own wasm_ref_t* call_r_r(const wasm_func_t* func, wasm_ref_t* ref) {
 }
 
 void call_ir_v(const wasm_func_t* func, int32_t i, wasm_ref_t* ref) {
-  printf("call_ir_v... "); fflush(stdout);
+  printf("call_ir_v... ");
+  fflush(stdout);
   wasm_val_t args[2];
   args[0].kind = WASM_I32;
   args[0].of.i32 = i;
@@ -97,7 +96,8 @@ void call_ir_v(const wasm_func_t* func, int32_t i, wasm_ref_t* ref) {
 }
 
 own wasm_ref_t* call_i_r(const wasm_func_t* func, int32_t i) {
-  printf("call_i_r... "); fflush(stdout);
+  printf("call_i_r... ");
+  fflush(stdout);
   wasm_val_t args[1];
   args[0].kind = WASM_I32;
   args[0].of.i32 = i;
@@ -114,13 +114,13 @@ void check(own wasm_ref_t* actual, const wasm_ref_t* expected) {
   if (actual != expected &&
       !(actual && expected && wasm_ref_same(actual, expected))) {
     printf("> Error reading reference, expected %p, got %p\n",
-      expected ? wasm_ref_get_host_info(expected) : NULL,
-      actual ? wasm_ref_get_host_info(actual) : NULL);
+           expected ? wasm_ref_get_host_info(expected) : NULL,
+           actual ? wasm_ref_get_host_info(actual) : NULL);
     exit(1);
   }
-  if (actual) wasm_ref_delete(actual);
+  if (actual)
+    wasm_ref_delete(actual);
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -159,17 +159,17 @@ int main(int argc, const char* argv[]) {
   // Create external callback function.
   printf("Creating callback...\n");
   own wasm_functype_t* callback_type = wasm_functype_new_1_1(
-    wasm_valtype_new(WASM_ANYREF), wasm_valtype_new(WASM_ANYREF));
+      wasm_valtype_new(WASM_ANYREF), wasm_valtype_new(WASM_ANYREF));
   own wasm_func_t* callback_func =
-    wasm_func_new(store, callback_type, callback);
+      wasm_func_new(store, callback_type, callback);
 
   wasm_functype_delete(callback_type);
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(callback_func) };
+  const wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/hostref.cc
+++ b/example/hostref.cc
@@ -1,32 +1,34 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
 // A function to be called from Wasm code.
-auto callback(
-  const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto callback(const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
-  std::cout << "> " << (args[0].ref() ? args[0].ref()->get_host_info() : nullptr) << std::endl;
+  std::cout << "> "
+            << (args[0].ref() ? args[0].ref()->get_host_info() : nullptr)
+            << std::endl;
   results[0] = args[0].copy();
   return nullptr;
 }
 
-
-auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i) -> const wasm::Func* {
+auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> const wasm::Func* {
   if (exports.size() <= i || !exports[i]->func()) {
-    std::cout << "> Error accessing function export " << i << "/" << exports.size() << "!" << std::endl;
+    std::cout << "> Error accessing function export " << i << "/"
+              << exports.size() << "!" << std::endl;
     exit(1);
   }
   return exports[i]->func();
 }
 
-auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Global* {
+auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> wasm::Global* {
   if (exports.size() <= i || !exports[i]->global()) {
     std::cout << "> Error accessing global export " << i << "!" << std::endl;
     exit(1);
@@ -34,7 +36,8 @@ auto get_export_global(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::G
   return exports[i]->global();
 }
 
-auto get_export_table(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Table* {
+auto get_export_table(wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> wasm::Table* {
   if (exports.size() <= i || !exports[i]->table()) {
     std::cout << "> Error accessing table export " << i << "!" << std::endl;
     exit(1);
@@ -42,10 +45,10 @@ auto get_export_table(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Ta
   return exports[i]->table();
 }
 
-
 void call_r_v(const wasm::Func* func, const wasm::Ref* ref) {
   std::cout << "call_r_v... " << std::flush;
-  wasm::Val args[1] = {wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
+  wasm::Val args[1] = {
+      wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
   if (func->call(args, nullptr)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
@@ -64,9 +67,11 @@ auto call_v_r(const wasm::Func* func) -> wasm::own<wasm::Ref> {
   return results[0].release_ref();
 }
 
-auto call_r_r(const wasm::Func* func, const wasm::Ref* ref) -> wasm::own<wasm::Ref> {
+auto call_r_r(const wasm::Func* func, const wasm::Ref* ref)
+    -> wasm::own<wasm::Ref> {
   std::cout << "call_r_r... " << std::flush;
-  wasm::Val args[1] = {wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
+  wasm::Val args[1] = {
+      wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
   wasm::Val results[1];
   if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
@@ -78,7 +83,9 @@ auto call_r_r(const wasm::Func* func, const wasm::Ref* ref) -> wasm::own<wasm::R
 
 void call_ir_v(const wasm::Func* func, int32_t i, const wasm::Ref* ref) {
   std::cout << "call_ir_v... " << std::flush;
-  wasm::Val args[2] = {wasm::Val::i32(i), wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
+  wasm::Val args[2] = {
+      wasm::Val::i32(i),
+      wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
   if (func->call(args, nullptr)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
@@ -102,8 +109,8 @@ void check(wasm::own<wasm::Ref> actual, const wasm::Ref* expected) {
   if (actual.get() != expected &&
       !(actual && expected && actual->same(expected))) {
     std::cout << "> Error reading reference, expected "
-      << (expected ? expected->get_host_info() : nullptr) << ", got "
-      << (actual ? actual->get_host_info() : nullptr) << std::endl;
+              << (expected ? expected->get_host_info() : nullptr) << ", got "
+              << (actual ? actual->get_host_info() : nullptr) << std::endl;
     exit(1);
   }
 }
@@ -140,9 +147,8 @@ void run() {
   // Create external callback function.
   std::cout << "Creating callback..." << std::endl;
   auto callback_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::ANYREF)),
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::ANYREF))
-  );
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::ANYREF)),
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::ANYREF)));
   auto callback_func = wasm::Func::make(store, callback_type.get(), callback);
 
   // Instantiate.
@@ -223,10 +229,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/memory.c
+++ b/example/memory.c
@@ -1,12 +1,11 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
-
 
 wasm_memory_t* get_export_memory(const wasm_extern_vec_t* exports, size_t i) {
   if (exports->size <= i || !wasm_extern_as_memory(exports->data[i])) {
@@ -23,7 +22,6 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
   }
   return wasm_extern_as_func(exports->data[i]);
 }
-
 
 void check(bool success) {
   if (!success) {
@@ -45,15 +43,16 @@ void check_call0(wasm_func_t* func, int32_t expected) {
 }
 
 void check_call1(wasm_func_t* func, int32_t arg, int32_t expected) {
-  wasm_val_t args[] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
+  wasm_val_t args[] = {{.kind = WASM_I32, .of = {.i32 = arg}}};
   check_call(func, args, expected);
 }
 
-void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+void check_call2(wasm_func_t* func,
+                 int32_t arg1,
+                 int32_t arg2,
+                 int32_t expected) {
+  wasm_val_t args[2] = {{.kind = WASM_I32, .of = {.i32 = arg1}},
+                        {.kind = WASM_I32, .of = {.i32 = arg2}}};
   check_call(func, args, expected);
 }
 
@@ -65,17 +64,15 @@ void check_ok(wasm_func_t* func, wasm_val_t args[]) {
 }
 
 void check_ok2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+  wasm_val_t args[2] = {{.kind = WASM_I32, .of = {.i32 = arg1}},
+                        {.kind = WASM_I32, .of = {.i32 = arg2}}};
   check_ok(func, args);
 }
 
 void check_trap(wasm_func_t* func, wasm_val_t args[]) {
   wasm_val_t results[1];
   own wasm_trap_t* trap = wasm_func_call(func, args, results);
-  if (! trap) {
+  if (!trap) {
     printf("> Error on result, expected trap\n");
     exit(1);
   }
@@ -83,18 +80,15 @@ void check_trap(wasm_func_t* func, wasm_val_t args[]) {
 }
 
 void check_trap1(wasm_func_t* func, int32_t arg) {
-  wasm_val_t args[1] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
+  wasm_val_t args[1] = {{.kind = WASM_I32, .of = {.i32 = arg}}};
   check_trap(func, args);
 }
 
 void check_trap2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+  wasm_val_t args[2] = {{.kind = WASM_I32, .of = {.i32 = arg1}},
+                        {.kind = WASM_I32, .of = {.i32 = arg2}}};
   check_trap(func, args);
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -192,7 +186,7 @@ int main(int argc, const char* argv[]) {
   check_trap1(load_func, 0x30000);
   check_trap2(store_func, 0x30000, 0);
 
-  check(! wasm_memory_grow(memory, 1));
+  check(!wasm_memory_grow(memory, 1));
   check(wasm_memory_grow(memory, 0));
 
   wasm_extern_vec_delete(&exports);
@@ -205,7 +199,7 @@ int main(int argc, const char* argv[]) {
   own wasm_memorytype_t* memorytype = wasm_memorytype_new(&limits);
   own wasm_memory_t* memory2 = wasm_memory_new(store, memorytype);
   check(wasm_memory_size(memory2) == 5);
-  check(! wasm_memory_grow(memory2, 1));
+  check(!wasm_memory_grow(memory2, 1));
   check(wasm_memory_grow(memory2, 0));
 
   wasm_memorytype_delete(memorytype);

--- a/example/memory.cc
+++ b/example/memory.cc
@@ -1,13 +1,13 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
-auto get_export_memory(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Memory* {
+auto get_export_memory(wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> wasm::Memory* {
   if (exports.size() <= i || !exports[i]->memory()) {
     std::cout << "> Error accessing memory export " << i << "!" << std::endl;
     exit(1);
@@ -15,7 +15,8 @@ auto get_export_memory(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::M
   return exports[i]->memory();
 }
 
-auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i) -> const wasm::Func* {
+auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i)
+    -> const wasm::Func* {
   if (exports.size() <= i || !exports[i]->func()) {
     std::cout << "> Error accessing function export " << i << "!" << std::endl;
     exit(1);
@@ -23,15 +24,16 @@ auto get_export_func(const wasm::ownvec<wasm::Extern>& exports, size_t i) -> con
   return exports[i]->func();
 }
 
-template<class T, class U>
+template <class T, class U>
 void check(T actual, U expected) {
   if (actual != expected) {
-    std::cout << "> Error on result, expected " << expected << ", got " << actual << std::endl;
+    std::cout << "> Error on result, expected " << expected << ", got "
+              << actual << std::endl;
     exit(1);
   }
 }
 
-template<class... Args>
+template <class... Args>
 void check_ok(const wasm::Func* func, Args... xs) {
   wasm::Val args[] = {wasm::Val::i32(xs)...};
   if (func->call(args)) {
@@ -40,16 +42,16 @@ void check_ok(const wasm::Func* func, Args... xs) {
   }
 }
 
-template<class... Args>
+template <class... Args>
 void check_trap(const wasm::Func* func, Args... xs) {
   wasm::Val args[] = {wasm::Val::i32(xs)...};
-  if (! func->call(args)) {
+  if (!func->call(args)) {
     std::cout << "> Error on result, expected trap" << std::endl;
     exit(1);
   }
 }
 
-template<class... Args>
+template <class... Args>
 auto call(const wasm::Func* func, Args... xs) -> int32_t {
   wasm::Val args[] = {wasm::Val::i32(xs)...};
   wasm::Val results[1];
@@ -59,7 +61,6 @@ auto call(const wasm::Func* func, Args... xs) -> int32_t {
   }
   return results[0].i32();
 }
-
 
 void run() {
   // Initialize.
@@ -163,10 +164,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/multi.c
+++ b/example/multi.c
@@ -1,19 +1,17 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
 
 // A function to be called from Wasm code.
-own wasm_trap_t* callback(
-  const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("Calling back...\n> ");
-  printf("> %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu32"\n",
-    args[0].of.i32, args[1].of.i64, args[2].of.i64, args[3].of.i32);
+  printf("> %" PRIu32 " %" PRIu64 " %" PRIu64 " %" PRIu32 "\n", args[0].of.i32,
+         args[1].of.i64, args[2].of.i64, args[3].of.i32);
   printf("\n");
 
   wasm_val_copy(&results[0], &args[3]);
@@ -23,11 +21,10 @@ own wasm_trap_t* callback(
   return NULL;
 }
 
-
 // A function closure.
-own wasm_trap_t* closure_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* closure_callback(void* env,
+                                  const wasm_val_t args[],
+                                  wasm_val_t results[]) {
   int i = *(int*)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
@@ -36,7 +33,6 @@ own wasm_trap_t* closure_callback(
   results[0].of.i32 = (int32_t)i;
   return NULL;
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -74,16 +70,14 @@ int main(int argc, const char* argv[]) {
 
   // Create external print functions.
   printf("Creating callback...\n");
-  wasm_valtype_t* types[4] = {
-    wasm_valtype_new_i32(), wasm_valtype_new_i64(),
-    wasm_valtype_new_i64(), wasm_valtype_new_i32()
-  };
+  wasm_valtype_t* types[4] = {wasm_valtype_new_i32(), wasm_valtype_new_i64(),
+                              wasm_valtype_new_i64(), wasm_valtype_new_i32()};
   own wasm_valtype_vec_t tuple1, tuple2;
   wasm_valtype_vec_new(&tuple1, 4, types);
   wasm_valtype_vec_copy(&tuple2, &tuple1);
   own wasm_functype_t* callback_type = wasm_functype_new(&tuple1, &tuple2);
   own wasm_func_t* callback_func =
-    wasm_func_new(store, callback_type, callback);
+      wasm_func_new(store, callback_type, callback);
 
   wasm_functype_delete(callback_type);
 
@@ -91,7 +85,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   const wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -137,9 +131,9 @@ int main(int argc, const char* argv[]) {
 
   // Print result.
   printf("Printing result...\n");
-  printf("> %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu32"\n",
-    results[0].of.i32, results[1].of.i64,
-    results[2].of.i64, results[3].of.i32);
+  printf("> %" PRIu32 " %" PRIu64 " %" PRIu64 " %" PRIu32 "\n",
+         results[0].of.i32, results[1].of.i64, results[2].of.i64,
+         results[3].of.i32);
 
   assert(results[0].of.i32 == 4);
   assert(results[1].of.i64 == 3);

--- a/example/multi.cc
+++ b/example/multi.cc
@@ -1,15 +1,14 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
 // A function to be called from Wasm code.
-auto callback(
-  const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto callback(const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> " << args[0].i32();
   std::cout << " " << args[1].i64();
@@ -21,7 +20,6 @@ auto callback(
   results[3] = args[0].copy();
   return nullptr;
 }
-
 
 void run() {
   // Initialize.
@@ -55,13 +53,10 @@ void run() {
   // Create external print functions.
   std::cout << "Creating callback..." << std::endl;
   auto tuple = wasm::ownvec<wasm::ValType>::make(
-    wasm::ValType::make(wasm::I32),
-    wasm::ValType::make(wasm::I64),
-    wasm::ValType::make(wasm::I64),
-    wasm::ValType::make(wasm::I32)
-  );
+      wasm::ValType::make(wasm::I32), wasm::ValType::make(wasm::I64),
+      wasm::ValType::make(wasm::I64), wasm::ValType::make(wasm::I32));
   auto callback_type =
-    wasm::FuncType::make(tuple.deep_copy(), tuple.deep_copy());
+      wasm::FuncType::make(tuple.deep_copy(), tuple.deep_copy());
   auto callback_func = wasm::Func::make(store, callback_type.get(), callback);
 
   // Instantiate.
@@ -76,7 +71,8 @@ void run() {
   // Extract export.
   std::cout << "Extracting export..." << std::endl;
   auto exports = instance->exports();
-  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+      !exports[0]->func()) {
     std::cout << "> Error accessing export!" << std::endl;
     exit(1);
   }
@@ -84,12 +80,12 @@ void run() {
 
   // Call.
   std::cout << "Calling export..." << std::endl;
-  wasm::Val args[] = {
-    wasm::Val::i32(1), wasm::Val::i64(2), wasm::Val::i64(3), wasm::Val::i32(4)
-  };
+  wasm::Val args[] = {wasm::Val::i32(1), wasm::Val::i64(2), wasm::Val::i64(3),
+                      wasm::Val::i32(4)};
   wasm::Val results[4];
   if (wasm::own<wasm::Trap> trap = run_func->call(args, results)) {
-    std::cout << "> Error calling function! " << trap->message().get() << std::endl;
+    std::cout << "> Error calling function! " << trap->message().get()
+              << std::endl;
     exit(1);
   }
 
@@ -109,10 +105,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -1,7 +1,7 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
@@ -9,24 +9,41 @@
 
 void print_mutability(wasm_mutability_t mut) {
   switch (mut) {
-    case WASM_VAR: printf("var"); break;
-    case WASM_CONST: printf("const"); break;
+    case WASM_VAR:
+      printf("var");
+      break;
+    case WASM_CONST:
+      printf("const");
+      break;
   }
 }
 
 void print_limits(const wasm_limits_t* limits) {
   printf("%ud", limits->min);
-  if (limits->max < wasm_limits_max_default) printf(" %ud", limits->max);
+  if (limits->max < wasm_limits_max_default)
+    printf(" %ud", limits->max);
 }
 
 void print_valtype(const wasm_valtype_t* type) {
   switch (wasm_valtype_kind(type)) {
-    case WASM_I32: printf("i32"); break;
-    case WASM_I64: printf("i64"); break;
-    case WASM_F32: printf("f32"); break;
-    case WASM_F64: printf("f64"); break;
-    case WASM_ANYREF: printf("anyref"); break;
-    case WASM_FUNCREF: printf("funcref"); break;
+    case WASM_I32:
+      printf("i32");
+      break;
+    case WASM_I64:
+      printf("i64");
+      break;
+    case WASM_F32:
+      printf("f32");
+      break;
+    case WASM_F64:
+      printf("f64");
+      break;
+    case WASM_ANYREF:
+      printf("anyref");
+      break;
+    case WASM_FUNCREF:
+      printf("funcref");
+      break;
   }
 }
 
@@ -45,8 +62,7 @@ void print_valtypes(const wasm_valtype_vec_t* types) {
 void print_externtype(const wasm_externtype_t* type) {
   switch (wasm_externtype_kind(type)) {
     case WASM_EXTERN_FUNC: {
-      const wasm_functype_t* functype =
-        wasm_externtype_as_functype_const(type);
+      const wasm_functype_t* functype = wasm_externtype_as_functype_const(type);
       printf("func ");
       print_valtypes(wasm_functype_params(functype));
       printf(" -> ");
@@ -54,7 +70,7 @@ void print_externtype(const wasm_externtype_t* type) {
     } break;
     case WASM_EXTERN_GLOBAL: {
       const wasm_globaltype_t* globaltype =
-        wasm_externtype_as_globaltype_const(type);
+          wasm_externtype_as_globaltype_const(type);
       printf("global ");
       print_mutability(wasm_globaltype_mutability(globaltype));
       printf(" ");
@@ -62,7 +78,7 @@ void print_externtype(const wasm_externtype_t* type) {
     } break;
     case WASM_EXTERN_TABLE: {
       const wasm_tabletype_t* tabletype =
-        wasm_externtype_as_tabletype_const(type);
+          wasm_externtype_as_tabletype_const(type);
       printf("table ");
       print_limits(wasm_tabletype_limits(tabletype));
       printf(" ");
@@ -70,7 +86,7 @@ void print_externtype(const wasm_externtype_t* type) {
     } break;
     case WASM_EXTERN_MEMORY: {
       const wasm_memorytype_t* memorytype =
-        wasm_externtype_as_memorytype_const(type);
+          wasm_externtype_as_memorytype_const(type);
       printf("memory ");
       print_limits(wasm_memorytype_limits(memorytype));
     } break;
@@ -80,7 +96,6 @@ void print_externtype(const wasm_externtype_t* type) {
 void print_name(const wasm_name_t* name) {
   printf("\"%.*s\"", (int)name->size, name->data);
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -134,7 +149,7 @@ int main(int argc, const char* argv[]) {
 
   for (size_t i = 0; i < exports.size; ++i) {
     assert(wasm_extern_kind(exports.data[i]) ==
-      wasm_externtype_kind(wasm_exporttype_type(export_types.data[i])));
+           wasm_externtype_kind(wasm_exporttype_type(export_types.data[i])));
     printf("> export %zu ", i);
     print_name(wasm_exporttype_name(export_types.data[i]));
     printf("\n");

--- a/example/reflect.cc
+++ b/example/reflect.cc
@@ -1,39 +1,48 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
 auto operator<<(std::ostream& out, wasm::Mutability mut) -> std::ostream& {
   switch (mut) {
-    case wasm::VAR: return out << "var";
-    case wasm::CONST: return out << "const";
+    case wasm::VAR:
+      return out << "var";
+    case wasm::CONST:
+      return out << "const";
   }
   return out;
 }
 
 auto operator<<(std::ostream& out, wasm::Limits limits) -> std::ostream& {
   out << limits.min;
-  if (limits.max < wasm::Limits(0).max) out << " " << limits.max;
+  if (limits.max < wasm::Limits(0).max)
+    out << " " << limits.max;
   return out;
 }
 
 auto operator<<(std::ostream& out, const wasm::ValType& type) -> std::ostream& {
   switch (type.kind()) {
-    case wasm::I32: return out << "i32";
-    case wasm::I64: return out << "i64";
-    case wasm::F32: return out << "f32";
-    case wasm::F64: return out << "f64";
-    case wasm::ANYREF: return out << "anyref";
-    case wasm::FUNCREF: return out << "funcref";
+    case wasm::I32:
+      return out << "i32";
+    case wasm::I64:
+      return out << "i64";
+    case wasm::F32:
+      return out << "f32";
+    case wasm::F64:
+      return out << "f64";
+    case wasm::ANYREF:
+      return out << "anyref";
+    case wasm::FUNCREF:
+      return out << "funcref";
   }
   return out;
 }
 
-auto operator<<(std::ostream& out, const wasm::ownvec<wasm::ValType>& types) -> std::ostream& {
+auto operator<<(std::ostream& out, const wasm::ownvec<wasm::ValType>& types)
+    -> std::ostream& {
   bool first = true;
   for (size_t i = 0; i < types.size(); ++i) {
     if (first) {
@@ -46,16 +55,20 @@ auto operator<<(std::ostream& out, const wasm::ownvec<wasm::ValType>& types) -> 
   return out;
 }
 
-auto operator<<(std::ostream& out, const wasm::ExternType& type) -> std::ostream& {
+auto operator<<(std::ostream& out, const wasm::ExternType& type)
+    -> std::ostream& {
   switch (type.kind()) {
     case wasm::EXTERN_FUNC: {
-      out << "func " << type.func()->params() << " -> " << type.func()->results();
+      out << "func " << type.func()->params() << " -> "
+          << type.func()->results();
     } break;
     case wasm::EXTERN_GLOBAL: {
-      out << "global " << type.global()->mutability() << " " << *type.global()->content();
+      out << "global " << type.global()->mutability() << " "
+          << *type.global()->content();
     } break;
     case wasm::EXTERN_TABLE: {
-      out << "table " << type.table()->limits() << " " << *type.table()->element();
+      out << "table " << type.table()->limits() << " "
+          << *type.table()->element();
     } break;
     case wasm::EXTERN_MEMORY: {
       out << "memory " << type.memory()->limits();
@@ -68,7 +81,6 @@ auto operator<<(std::ostream& out, const wasm::Name& name) -> std::ostream& {
   out << "\"" << std::string(name.get(), name.size()) << "\"";
   return out;
 }
-
 
 void run() {
   // Initialize.
@@ -115,7 +127,8 @@ void run() {
 
   for (size_t i = 0; i < exports.size(); ++i) {
     assert(exports[i]->kind() == export_types[i]->type()->kind());
-    std::cout << "> export " << i << " " << export_types[i]->name() << std::endl;
+    std::cout << "> export " << i << " " << export_types[i]->name()
+              << std::endl;
     std::cout << ">> initial: " << *export_types[i]->type() << std::endl;
     std::cout << ">> current: " << *exports[i]->type() << std::endl;
     if (exports[i]->kind() == wasm::EXTERN_FUNC) {
@@ -129,10 +142,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -1,7 +1,7 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
@@ -13,7 +13,6 @@ own wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("> Hello World!\n");
   return NULL;
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -70,15 +69,15 @@ int main(int argc, const char* argv[]) {
   printf("Creating callback...\n");
   own wasm_functype_t* hello_type = wasm_functype_new_0_0();
   own wasm_func_t* hello_func =
-    wasm_func_new(store, hello_type, hello_callback);
+      wasm_func_new(store, hello_type, hello_callback);
 
   wasm_functype_delete(hello_type);
 
   // Instantiate.
   printf("Instantiating deserialized module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  const wasm_extern_t* imports[] = {wasm_func_as_extern(hello_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, deserialized, imports, NULL);
+      wasm_instance_new(store, deserialized, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/serialize.cc
+++ b/example/serialize.cc
@@ -1,21 +1,18 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
-
 // A function to be called from Wasm code.
-auto hello_callback(
-  const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto hello_callback(const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> Hello world!" << std::endl;
   return nullptr;
 }
-
 
 void run() {
   // Initialize.
@@ -60,9 +57,8 @@ void run() {
 
   // Create external print functions.
   std::cout << "Creating callback..." << std::endl;
-  auto hello_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(), wasm::ownvec<wasm::ValType>::make()
-  );
+  auto hello_type = wasm::FuncType::make(wasm::ownvec<wasm::ValType>::make(),
+                                         wasm::ownvec<wasm::ValType>::make());
   auto hello_func = wasm::Func::make(store, hello_type.get(), hello_callback);
 
   // Instantiate.
@@ -77,7 +73,8 @@ void run() {
   // Extract export.
   std::cout << "Extracting export..." << std::endl;
   auto exports = instance->exports();
-  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+      !exports[0]->func()) {
     std::cout << "> Error accessing export!" << std::endl;
     exit(1);
   }
@@ -94,10 +91,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/start.c
+++ b/example/start.c
@@ -1,22 +1,17 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
 
-
 void print_frame(wasm_frame_t* frame) {
-  printf("> %p @ 0x%zx = %"PRIu32".0x%zx\n",
-    wasm_frame_instance(frame),
-    wasm_frame_module_offset(frame),
-    wasm_frame_func_index(frame),
-    wasm_frame_func_offset(frame)
-  );
+  printf("> %p @ 0x%zx = %" PRIu32 ".0x%zx\n", wasm_frame_instance(frame),
+         wasm_frame_module_offset(frame), wasm_frame_func_index(frame),
+         wasm_frame_func_offset(frame));
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -55,8 +50,7 @@ int main(int argc, const char* argv[]) {
   // Instantiate.
   printf("Instantiating module...\n");
   own wasm_trap_t* trap = NULL;
-  own wasm_instance_t* instance =
-    wasm_instance_new(store, module, NULL, &trap);
+  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, &trap);
   if (instance || !trap) {
     printf("> Error instantiating module, expected trap!\n");
     return 1;

--- a/example/start.cc
+++ b/example/start.cc
@@ -1,11 +1,10 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
-
 
 void print_frame(const wasm::Frame* frame) {
   std::cout << "> " << frame->instance();
@@ -13,7 +12,6 @@ void print_frame(const wasm::Frame* frame) {
   std::cout << " = " << frame->func_index();
   std::cout << ".0x" << std::hex << frame->func_offset() << std::endl;
 }
-
 
 void run() {
   // Initialize.
@@ -79,10 +77,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/example/threads.c
+++ b/example/threads.c
@@ -1,8 +1,8 @@
 #include <inttypes.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 #include <unistd.h>
 
 #include "wasm.h"
@@ -18,7 +18,6 @@ own wasm_trap_t* callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("> Thread %d running\n", args[0].of.i32);
   return NULL;
 }
-
 
 typedef struct {
   wasm_engine_t* engine;
@@ -38,22 +37,24 @@ void* run(void* args_abs) {
     usleep(100000);
 
     // Create imports.
-    own wasm_functype_t* func_type = wasm_functype_new_1_0(wasm_valtype_new_i32());
+    own wasm_functype_t* func_type =
+        wasm_functype_new_1_0(wasm_valtype_new_i32());
     own wasm_func_t* func = wasm_func_new(store, func_type, callback);
     wasm_functype_delete(func_type);
 
     wasm_val_t val = {.kind = WASM_I32, .of = {.i32 = (int32_t)args->id}};
     own wasm_globaltype_t* global_type =
-      wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
+        wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
     own wasm_global_t* global = wasm_global_new(store, global_type, &val);
     wasm_globaltype_delete(global_type);
 
     // Instantiate.
     const wasm_extern_t* imports[] = {
-      wasm_func_as_extern(func), wasm_global_as_extern(global),
+        wasm_func_as_extern(func),
+        wasm_global_as_extern(global),
     };
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, imports, NULL);
+        wasm_instance_new(store, module, imports, NULL);
     if (!instance) {
       printf("> Error instantiating module!\n");
       return NULL;
@@ -69,7 +70,7 @@ void* run(void* args_abs) {
       printf("> Error accessing exports!\n");
       return NULL;
     }
-    const wasm_func_t *run_func = wasm_extern_as_func(exports.data[0]);
+    const wasm_func_t* run_func = wasm_extern_as_func(exports.data[0]);
     if (run_func == NULL) {
       printf("> Error accessing export!\n");
       return NULL;
@@ -94,7 +95,7 @@ void* run(void* args_abs) {
   return NULL;
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, const char* argv[]) {
   // Initialize.
   wasm_engine_t* engine = wasm_engine_new();
 

--- a/example/threads.cc
+++ b/example/threads.cc
@@ -1,7 +1,7 @@
-#include <iostream>
 #include <fstream>
-#include <thread>
+#include <iostream>
 #include <mutex>
+#include <thread>
 
 #include "wasm.hh"
 
@@ -9,9 +9,8 @@ const int N_THREADS = 10;
 const int N_REPS = 3;
 
 // A function to be called from Wasm code.
-auto callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto callback(void* env, const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   assert(args[0].kind() == wasm::I32);
   std::lock_guard<std::mutex>(*reinterpret_cast<std::mutex*>(env));
   std::cout << "Thread " << args[0].i32() << " running..." << std::endl;
@@ -19,11 +18,10 @@ auto callback(
   return nullptr;
 }
 
-
-void run(
-  wasm::Engine* engine, const wasm::Shared<wasm::Module>* shared,
-  std::mutex* mutex, int id
-) {
+void run(wasm::Engine* engine,
+         const wasm::Shared<wasm::Module>* shared,
+         std::mutex* mutex,
+         int id) {
   // Create store.
   auto store_ = wasm::Store::make(engine);
   auto store = store_.get();
@@ -42,15 +40,14 @@ void run(
 
     // Create imports.
     auto func_type = wasm::FuncType::make(
-      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)),
-      wasm::ownvec<wasm::ValType>::make()
-    );
+        wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)),
+        wasm::ownvec<wasm::ValType>::make());
     auto func = wasm::Func::make(store, func_type.get(), callback, mutex);
 
-    auto global_type = wasm::GlobalType::make(
-      wasm::ValType::make(wasm::I32), wasm::CONST);
-    auto global = wasm::Global::make(
-      store, global_type.get(), wasm::Val::i32(i));
+    auto global_type =
+        wasm::GlobalType::make(wasm::ValType::make(wasm::I32), wasm::CONST);
+    auto global =
+        wasm::Global::make(store, global_type.get(), wasm::Val::i32(i));
 
     // Instantiate.
     wasm::Extern* imports[] = {func.get(), global.get()};
@@ -63,7 +60,8 @@ void run(
 
     // Extract export.
     auto exports = instance->exports();
-    if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+    if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+        !exports[0]->func()) {
       std::lock_guard<std::mutex> lock(*mutex);
       std::cout << "> Error accessing export!" << std::endl;
       exit(1);
@@ -75,7 +73,7 @@ void run(
   }
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
   auto engine = wasm::Engine::make();

--- a/example/trap.c
+++ b/example/trap.c
@@ -1,16 +1,16 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "wasm.h"
 
 #define own
 
 // A function to be called from Wasm code.
-own wasm_trap_t* fail_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
-) {
+own wasm_trap_t* fail_callback(void* env,
+                               const wasm_val_t args[],
+                               wasm_val_t results[]) {
   printf("Calling back...\n");
   own wasm_name_t message;
   wasm_name_new_from_string(&message, "callback abort");
@@ -19,16 +19,11 @@ own wasm_trap_t* fail_callback(
   return trap;
 }
 
-
 void print_frame(wasm_frame_t* frame) {
-  printf("> %p @ 0x%zx = %"PRIu32".0x%zx\n",
-    wasm_frame_instance(frame),
-    wasm_frame_module_offset(frame),
-    wasm_frame_func_index(frame),
-    wasm_frame_func_offset(frame)
-  );
+  printf("> %p @ 0x%zx = %" PRIu32 ".0x%zx\n", wasm_frame_instance(frame),
+         wasm_frame_module_offset(frame), wasm_frame_func_index(frame),
+         wasm_frame_func_offset(frame));
 }
-
 
 int main(int argc, const char* argv[]) {
   // Initialize.
@@ -67,17 +62,17 @@ int main(int argc, const char* argv[]) {
   // Create external print functions.
   printf("Creating callback...\n");
   own wasm_functype_t* fail_type =
-    wasm_functype_new_0_1(wasm_valtype_new_i32());
+      wasm_functype_new_0_1(wasm_valtype_new_i32());
   own wasm_func_t* fail_func =
-    wasm_func_new_with_env(store, fail_type, fail_callback, store, NULL);
+      wasm_func_new_with_env(store, fail_type, fail_callback, store, NULL);
 
   wasm_functype_delete(fail_type);
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
+  const wasm_extern_t* imports[] = {wasm_func_as_extern(fail_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+      wasm_instance_new(store, module, imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/trap.cc
+++ b/example/trap.cc
@@ -1,21 +1,19 @@
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <string>
 #include <cinttypes>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "wasm.hh"
 
 // A function to be called from Wasm code.
-auto fail_callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
-) -> wasm::own<wasm::Trap> {
+auto fail_callback(void* env, const wasm::Val args[], wasm::Val results[])
+    -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   auto store = reinterpret_cast<wasm::Store*>(env);
   auto message = wasm::Name::make(std::string("callback abort"));
   return wasm::Trap::make(store, message);
 }
-
 
 void print_frame(const wasm::Frame* frame) {
   std::cout << "> " << frame->instance();
@@ -23,7 +21,6 @@ void print_frame(const wasm::Frame* frame) {
   std::cout << " = " << frame->func_index();
   std::cout << ".0x" << std::hex << frame->func_offset() << std::endl;
 }
-
 
 void run() {
   // Initialize.
@@ -57,11 +54,10 @@ void run() {
   // Create external print functions.
   std::cout << "Creating callback..." << std::endl;
   auto fail_type = wasm::FuncType::make(
-    wasm::ownvec<wasm::ValType>::make(),
-    wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32))
-  );
+      wasm::ownvec<wasm::ValType>::make(),
+      wasm::ownvec<wasm::ValType>::make(wasm::ValType::make(wasm::I32)));
   auto fail_func =
-    wasm::Func::make(store, fail_type.get(), fail_callback, store);
+      wasm::Func::make(store, fail_type.get(), fail_callback, store);
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
@@ -75,9 +71,9 @@ void run() {
   // Extract export.
   std::cout << "Extracting exports..." << std::endl;
   auto exports = instance->exports();
-  if (exports.size() < 2 ||
-      exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func() ||
-      exports[1]->kind() != wasm::EXTERN_FUNC || !exports[1]->func()) {
+  if (exports.size() < 2 || exports[0]->kind() != wasm::EXTERN_FUNC ||
+      !exports[0]->func() || exports[1]->kind() != wasm::EXTERN_FUNC ||
+      !exports[1]->func()) {
     std::cout << "> Error accessing exports!" << std::endl;
     exit(1);
   }
@@ -117,10 +113,8 @@ void run() {
   std::cout << "Shutting down..." << std::endl;
 }
 
-
 int main(int argc, const char* argv[]) {
   run();
   std::cout << "Done." << std::endl;
   return 0;
 }
-

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -3,12 +3,11 @@
 #ifndef __WASM_H
 #define __WASM_H
 
+#include <assert.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
 #include <string.h>
-#include <assert.h>
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,14 +22,13 @@ inline void assertions() {
   static_assert(sizeof(float) == sizeof(uint32_t), "incompatible float type");
   static_assert(sizeof(double) == sizeof(uint64_t), "incompatible double type");
   static_assert(sizeof(intptr_t) == sizeof(uint32_t) ||
-                sizeof(intptr_t) == sizeof(uint64_t),
+                    sizeof(intptr_t) == sizeof(uint64_t),
                 "incompatible pointer type");
 }
 
 typedef char byte_t;
 typedef float float32_t;
 typedef double float64_t;
-
 
 // Ownership
 
@@ -57,31 +55,27 @@ typedef double float64_t;
 // neither the vector nor its elements should be modified.
 // TODO: introduce proper `wasm_xxx_const_vec_t`?
 
-
-#define WASM_DECLARE_OWN(name) \
+#define WASM_DECLARE_OWN(name)                    \
   typedef struct wasm_##name##_t wasm_##name##_t; \
-  \
+                                                  \
   void wasm_##name##_delete(own wasm_##name##_t*);
-
 
 // Vectors
 
-#define WASM_DECLARE_VEC(name, ptr_or_none) \
-  typedef struct wasm_##name##_vec_t { \
-    size_t size; \
-    wasm_##name##_t ptr_or_none* data; \
-  } wasm_##name##_vec_t; \
-  \
-  void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
-  void wasm_##name##_vec_new_uninitialized( \
-    own wasm_##name##_vec_t* out, size_t); \
-  void wasm_##name##_vec_new( \
-    own wasm_##name##_vec_t* out, \
-    size_t, own wasm_##name##_t ptr_or_none const[]); \
-  void wasm_##name##_vec_copy( \
-    own wasm_##name##_vec_t* out, const wasm_##name##_vec_t*); \
+#define WASM_DECLARE_VEC(name, ptr_or_none)                              \
+  typedef struct wasm_##name##_vec_t {                                   \
+    size_t size;                                                         \
+    wasm_##name##_t ptr_or_none* data;                                   \
+  } wasm_##name##_vec_t;                                                 \
+                                                                         \
+  void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out);        \
+  void wasm_##name##_vec_new_uninitialized(own wasm_##name##_vec_t* out, \
+                                           size_t);                      \
+  void wasm_##name##_vec_new(own wasm_##name##_vec_t* out, size_t,       \
+                             own wasm_##name##_t ptr_or_none const[]);   \
+  void wasm_##name##_vec_copy(own wasm_##name##_vec_t* out,              \
+                              const wasm_##name##_vec_t*);               \
   void wasm_##name##_vec_delete(own wasm_##name##_vec_t*);
-
 
 // Byte vectors
 
@@ -97,12 +91,10 @@ typedef wasm_byte_vec_t wasm_name_t;
 #define wasm_name_copy wasm_byte_vec_copy
 #define wasm_name_delete wasm_byte_vec_delete
 
-static inline void wasm_name_new_from_string(
-  own wasm_name_t* out, const char* s
-) {
+static inline void wasm_name_new_from_string(own wasm_name_t* out,
+                                             const char* s) {
   wasm_name_new(out, strlen(s) + 1, s);
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
@@ -115,7 +107,6 @@ own wasm_config_t* wasm_config_new();
 
 // Embedders may provide custom functions for manipulating configs.
 
-
 // Engine
 
 WASM_DECLARE_OWN(engine)
@@ -123,13 +114,11 @@ WASM_DECLARE_OWN(engine)
 own wasm_engine_t* wasm_engine_new();
 own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
-
 // Store
 
 WASM_DECLARE_OWN(store)
 
 own wasm_store_t* wasm_store_new(wasm_engine_t*);
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Type Representations
@@ -149,15 +138,13 @@ typedef struct wasm_limits_t {
 
 static const uint32_t wasm_limits_max_default = 0xffffffff;
 
-
 // Generic
 
 #define WASM_DECLARE_TYPE(name) \
-  WASM_DECLARE_OWN(name) \
-  WASM_DECLARE_VEC(name, *) \
-  \
+  WASM_DECLARE_OWN(name)        \
+  WASM_DECLARE_VEC(name, *)     \
+                                \
   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
-
 
 // Value Types
 
@@ -191,39 +178,35 @@ static inline bool wasm_valtype_is_ref(const wasm_valtype_t* t) {
   return wasm_valkind_is_ref(wasm_valtype_kind(t));
 }
 
-
 // Function Types
 
 WASM_DECLARE_TYPE(functype)
 
-own wasm_functype_t* wasm_functype_new(
-  own wasm_valtype_vec_t* params, own wasm_valtype_vec_t* results);
+own wasm_functype_t* wasm_functype_new(own wasm_valtype_vec_t* params,
+                                       own wasm_valtype_vec_t* results);
 
 const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t*);
 const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t*);
-
 
 // Global Types
 
 WASM_DECLARE_TYPE(globaltype)
 
-own wasm_globaltype_t* wasm_globaltype_new(
-  own wasm_valtype_t*, wasm_mutability_t);
+own wasm_globaltype_t* wasm_globaltype_new(own wasm_valtype_t*,
+                                           wasm_mutability_t);
 
 const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
 wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
-
 
 // Table Types
 
 WASM_DECLARE_TYPE(tabletype)
 
-own wasm_tabletype_t* wasm_tabletype_new(
-  own wasm_valtype_t*, const wasm_limits_t*);
+own wasm_tabletype_t* wasm_tabletype_new(own wasm_valtype_t*,
+                                         const wasm_limits_t*);
 
 const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t*);
 const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t*);
-
 
 // Memory Types
 
@@ -232,7 +215,6 @@ WASM_DECLARE_TYPE(memorytype)
 own wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t*);
 
 const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t*);
-
 
 // Extern Types
 
@@ -258,39 +240,45 @@ wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
 wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
 wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
 
-const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
-const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
-const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
-const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
+const wasm_externtype_t* wasm_functype_as_externtype_const(
+    const wasm_functype_t*);
+const wasm_externtype_t* wasm_globaltype_as_externtype_const(
+    const wasm_globaltype_t*);
+const wasm_externtype_t* wasm_tabletype_as_externtype_const(
+    const wasm_tabletype_t*);
+const wasm_externtype_t* wasm_memorytype_as_externtype_const(
+    const wasm_memorytype_t*);
 
-const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
-const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
-const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
-const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
-
+const wasm_functype_t* wasm_externtype_as_functype_const(
+    const wasm_externtype_t*);
+const wasm_globaltype_t* wasm_externtype_as_globaltype_const(
+    const wasm_externtype_t*);
+const wasm_tabletype_t* wasm_externtype_as_tabletype_const(
+    const wasm_externtype_t*);
+const wasm_memorytype_t* wasm_externtype_as_memorytype_const(
+    const wasm_externtype_t*);
 
 // Import Types
 
 WASM_DECLARE_TYPE(importtype)
 
-own wasm_importtype_t* wasm_importtype_new(
-  own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
+own wasm_importtype_t* wasm_importtype_new(own wasm_name_t* module,
+                                           own wasm_name_t* name,
+                                           own wasm_externtype_t*);
 
 const wasm_name_t* wasm_importtype_module(const wasm_importtype_t*);
 const wasm_name_t* wasm_importtype_name(const wasm_importtype_t*);
 const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t*);
 
-
 // Export Types
 
 WASM_DECLARE_TYPE(exporttype)
 
-own wasm_exporttype_t* wasm_exporttype_new(
-  own wasm_name_t*, own wasm_externtype_t*);
+own wasm_exporttype_t* wasm_exporttype_new(own wasm_name_t*,
+                                           own wasm_externtype_t*);
 
 const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t*);
 const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t*);
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Objects
@@ -315,38 +303,36 @@ void wasm_val_copy(own wasm_val_t* out, const wasm_val_t*);
 
 WASM_DECLARE_VEC(val, )
 
-
 // References
 
-#define WASM_DECLARE_REF_BASE(name) \
-  WASM_DECLARE_OWN(name) \
-  \
-  own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
+#define WASM_DECLARE_REF_BASE(name)                                        \
+  WASM_DECLARE_OWN(name)                                                   \
+                                                                           \
+  own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);         \
   bool wasm_##name##_same(const wasm_##name##_t*, const wasm_##name##_t*); \
-  \
-  void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
-  void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
-  void wasm_##name##_set_host_info_with_finalizer( \
-    wasm_##name##_t*, void*, void (*)(void*));
+                                                                           \
+  void* wasm_##name##_get_host_info(const wasm_##name##_t*);               \
+  void wasm_##name##_set_host_info(wasm_##name##_t*, void*);               \
+  void wasm_##name##_set_host_info_with_finalizer(wasm_##name##_t*, void*, \
+                                                  void (*)(void*));
 
-#define WASM_DECLARE_REF(name) \
-  WASM_DECLARE_REF_BASE(name) \
-  \
-  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
-  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
+#define WASM_DECLARE_REF(name)                                          \
+  WASM_DECLARE_REF_BASE(name)                                           \
+                                                                        \
+  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*);                   \
+  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*);                     \
   const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t*); \
   const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t*);
 
-#define WASM_DECLARE_SHARABLE_REF(name) \
-  WASM_DECLARE_REF(name) \
-  WASM_DECLARE_OWN(shared_##name) \
-  \
+#define WASM_DECLARE_SHARABLE_REF(name)                                    \
+  WASM_DECLARE_REF(name)                                                   \
+  WASM_DECLARE_OWN(shared_##name)                                          \
+                                                                           \
   own wasm_shared_##name##_t* wasm_##name##_share(const wasm_##name##_t*); \
-  own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*, const wasm_shared_##name##_t*);
-
+  own wasm_##name##_t* wasm_##name##_obtain(wasm_store_t*,                 \
+                                            const wasm_shared_##name##_t*);
 
 WASM_DECLARE_REF_BASE(ref)
-
 
 // Frames
 
@@ -358,7 +344,6 @@ struct wasm_instance_t* wasm_frame_instance(const wasm_frame_t*);
 uint32_t wasm_frame_func_index(const wasm_frame_t*);
 size_t wasm_frame_func_offset(const wasm_frame_t*);
 size_t wasm_frame_module_offset(const wasm_frame_t*);
-
 
 // Traps
 
@@ -372,20 +357,18 @@ void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
 own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
 void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);
 
-
 // Foreign Objects
 
 WASM_DECLARE_REF(foreign)
 
 own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
 
-
 // Modules
 
 WASM_DECLARE_SHARABLE_REF(module)
 
-own wasm_module_t* wasm_module_new(
-  wasm_store_t*, const wasm_byte_vec_t* binary);
+own wasm_module_t* wasm_module_new(wasm_store_t*,
+                                   const wasm_byte_vec_t* binary);
 
 bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
 
@@ -393,44 +376,49 @@ void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
 void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 
 void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
-own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
-
+own wasm_module_t* wasm_module_deserialize(wasm_store_t*,
+                                           const wasm_byte_vec_t*);
 
 // Function Instances
 
 WASM_DECLARE_REF(func)
 
-typedef own wasm_trap_t* (*wasm_func_callback_t)(
-  const wasm_val_t args[], wasm_val_t results[]);
+typedef own wasm_trap_t* (*wasm_func_callback_t)(const wasm_val_t args[],
+                                                 wasm_val_t results[]);
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
-  void* env, const wasm_val_t args[], wasm_val_t results[]);
+    void* env,
+    const wasm_val_t args[],
+    wasm_val_t results[]);
 
-own wasm_func_t* wasm_func_new(
-  wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
-own wasm_func_t* wasm_func_new_with_env(
-  wasm_store_t*, const wasm_functype_t* type, wasm_func_callback_with_env_t,
-  void* env, void (*finalizer)(void*));
+own wasm_func_t* wasm_func_new(wasm_store_t*,
+                               const wasm_functype_t*,
+                               wasm_func_callback_t);
+own wasm_func_t* wasm_func_new_with_env(wasm_store_t*,
+                                        const wasm_functype_t* type,
+                                        wasm_func_callback_with_env_t,
+                                        void* env,
+                                        void (*finalizer)(void*));
 
 own wasm_functype_t* wasm_func_type(const wasm_func_t*);
 size_t wasm_func_param_arity(const wasm_func_t*);
 size_t wasm_func_result_arity(const wasm_func_t*);
 
-own wasm_trap_t* wasm_func_call(
-  const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
-
+own wasm_trap_t* wasm_func_call(const wasm_func_t*,
+                                const wasm_val_t args[],
+                                wasm_val_t results[]);
 
 // Global Instances
 
 WASM_DECLARE_REF(global)
 
-own wasm_global_t* wasm_global_new(
-  wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
+own wasm_global_t* wasm_global_new(wasm_store_t*,
+                                   const wasm_globaltype_t*,
+                                   const wasm_val_t*);
 
 own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
 void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
 void wasm_global_set(wasm_global_t*, const wasm_val_t*);
-
 
 // Table Instances
 
@@ -438,8 +426,9 @@ WASM_DECLARE_REF(table)
 
 typedef uint32_t wasm_table_size_t;
 
-own wasm_table_t* wasm_table_new(
-  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
+own wasm_table_t* wasm_table_new(wasm_store_t*,
+                                 const wasm_tabletype_t*,
+                                 wasm_ref_t* init);
 
 own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
@@ -448,7 +437,6 @@ bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
 
 wasm_table_size_t wasm_table_size(const wasm_table_t*);
 bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
-
 
 // Memory Instances
 
@@ -467,7 +455,6 @@ size_t wasm_memory_data_size(const wasm_memory_t*);
 
 wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);
 bool wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
-
 
 // Externals
 
@@ -497,18 +484,16 @@ const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
 const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
 const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
 
-
 // Module Instances
 
 WASM_DECLARE_REF(instance)
 
-own wasm_instance_t* wasm_instance_new(
-  wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
-  own wasm_trap_t**
-);
+own wasm_instance_t* wasm_instance_new(wasm_store_t*,
+                                       const wasm_module_t*,
+                                       const wasm_extern_t* const imports[],
+                                       own wasm_trap_t**);
 
 void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Convenience
@@ -535,7 +520,6 @@ static inline own wasm_valtype_t* wasm_valtype_new_funcref() {
   return wasm_valtype_new(WASM_FUNCREF);
 }
 
-
 // Function Types construction short-hands
 
 static inline own wasm_functype_t* wasm_functype_new_0_0() {
@@ -546,8 +530,7 @@ static inline own wasm_functype_t* wasm_functype_new_0_0() {
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_0(
-  own wasm_valtype_t* p
-) {
+    own wasm_valtype_t* p) {
   wasm_valtype_t* ps[1] = {p};
   wasm_valtype_vec_t params, results;
   wasm_valtype_vec_new(&params, 1, ps);
@@ -556,8 +539,8 @@ static inline own wasm_functype_t* wasm_functype_new_1_0(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_2_0(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2) {
   wasm_valtype_t* ps[2] = {p1, p2};
   wasm_valtype_vec_t params, results;
   wasm_valtype_vec_new(&params, 2, ps);
@@ -566,8 +549,9 @@ static inline own wasm_functype_t* wasm_functype_new_2_0(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_3_0(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2, own wasm_valtype_t* p3
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2,
+    own wasm_valtype_t* p3) {
   wasm_valtype_t* ps[3] = {p1, p2, p3};
   wasm_valtype_vec_t params, results;
   wasm_valtype_vec_new(&params, 3, ps);
@@ -576,8 +560,7 @@ static inline own wasm_functype_t* wasm_functype_new_3_0(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_0_1(
-  own wasm_valtype_t* r
-) {
+    own wasm_valtype_t* r) {
   wasm_valtype_t* rs[1] = {r};
   wasm_valtype_vec_t params, results;
   wasm_valtype_vec_new_empty(&params);
@@ -586,8 +569,8 @@ static inline own wasm_functype_t* wasm_functype_new_0_1(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_1(
-  own wasm_valtype_t* p, own wasm_valtype_t* r
-) {
+    own wasm_valtype_t* p,
+    own wasm_valtype_t* r) {
   wasm_valtype_t* ps[1] = {p};
   wasm_valtype_t* rs[1] = {r};
   wasm_valtype_vec_t params, results;
@@ -597,8 +580,9 @@ static inline own wasm_functype_t* wasm_functype_new_1_1(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_2_1(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2, own wasm_valtype_t* r
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2,
+    own wasm_valtype_t* r) {
   wasm_valtype_t* ps[2] = {p1, p2};
   wasm_valtype_t* rs[1] = {r};
   wasm_valtype_vec_t params, results;
@@ -608,9 +592,10 @@ static inline own wasm_functype_t* wasm_functype_new_2_1(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_3_1(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2, own wasm_valtype_t* p3,
-  own wasm_valtype_t* r
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2,
+    own wasm_valtype_t* p3,
+    own wasm_valtype_t* r) {
   wasm_valtype_t* ps[3] = {p1, p2, p3};
   wasm_valtype_t* rs[1] = {r};
   wasm_valtype_vec_t params, results;
@@ -620,8 +605,8 @@ static inline own wasm_functype_t* wasm_functype_new_3_1(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_0_2(
-  own wasm_valtype_t* r1, own wasm_valtype_t* r2
-) {
+    own wasm_valtype_t* r1,
+    own wasm_valtype_t* r2) {
   wasm_valtype_t* rs[2] = {r1, r2};
   wasm_valtype_vec_t params, results;
   wasm_valtype_vec_new_empty(&params);
@@ -630,8 +615,9 @@ static inline own wasm_functype_t* wasm_functype_new_0_2(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_2(
-  own wasm_valtype_t* p, own wasm_valtype_t* r1, own wasm_valtype_t* r2
-) {
+    own wasm_valtype_t* p,
+    own wasm_valtype_t* r1,
+    own wasm_valtype_t* r2) {
   wasm_valtype_t* ps[1] = {p};
   wasm_valtype_t* rs[2] = {r1, r2};
   wasm_valtype_vec_t params, results;
@@ -641,9 +627,10 @@ static inline own wasm_functype_t* wasm_functype_new_1_2(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_2_2(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2,
-  own wasm_valtype_t* r1, own wasm_valtype_t* r2
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2,
+    own wasm_valtype_t* r1,
+    own wasm_valtype_t* r2) {
   wasm_valtype_t* ps[2] = {p1, p2};
   wasm_valtype_t* rs[2] = {r1, r2};
   wasm_valtype_vec_t params, results;
@@ -653,9 +640,11 @@ static inline own wasm_functype_t* wasm_functype_new_2_2(
 }
 
 static inline own wasm_functype_t* wasm_functype_new_3_2(
-  own wasm_valtype_t* p1, own wasm_valtype_t* p2, own wasm_valtype_t* p3,
-  own wasm_valtype_t* r1, own wasm_valtype_t* r2
-) {
+    own wasm_valtype_t* p1,
+    own wasm_valtype_t* p2,
+    own wasm_valtype_t* p3,
+    own wasm_valtype_t* r1,
+    own wasm_valtype_t* r2) {
   wasm_valtype_t* ps[3] = {p1, p2, p3};
   wasm_valtype_t* rs[2] = {r1, r2};
   wasm_valtype_vec_t params, results;
@@ -663,7 +652,6 @@ static inline own wasm_functype_t* wasm_functype_new_3_2(
   wasm_valtype_vec_new(&results, 2, rs);
   return wasm_functype_new(&params, &results);
 }
-
 
 // Value construction short-hands
 
@@ -684,7 +672,6 @@ static inline void* wasm_val_ptr(const wasm_val_t* val) {
   return (void*)(intptr_t)val->of.i64;
 #endif
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -9,7 +9,10 @@ namespace bin {
 // Encoding
 
 void encode_header(char*& ptr) {
-  std::memcpy(ptr, "\x00""asm\x01\x00\x00\x00", 8);
+  std::memcpy(ptr,
+              "\x00"
+              "asm\x01\x00\x00\x00",
+              8);
   ptr += 8;
 }
 
@@ -49,44 +52,76 @@ void encode_size32(char*& ptr, size_t n) {
   }
 }
 
-
 void encode_valtype(char*& ptr, const ValType* type) {
   switch (type->kind()) {
-    case I32: *ptr++ = 0x7f; break;
-    case I64: *ptr++ = 0x7e; break;
-    case F32: *ptr++ = 0x7d; break;
-    case F64: *ptr++ = 0x7c; break;
-    case FUNCREF: *ptr++ = 0x70; break;
-    case ANYREF: *ptr++ = 0x6f; break;
-    default: assert(false);
+    case I32:
+      *ptr++ = 0x7f;
+      break;
+    case I64:
+      *ptr++ = 0x7e;
+      break;
+    case F32:
+      *ptr++ = 0x7d;
+      break;
+    case F64:
+      *ptr++ = 0x7c;
+      break;
+    case FUNCREF:
+      *ptr++ = 0x70;
+      break;
+    case ANYREF:
+      *ptr++ = 0x6f;
+      break;
+    default:
+      assert(false);
   }
 }
 
 auto zero_size(const ValType* type) -> size_t {
   switch (type->kind()) {
-    case I32: return 1;
-    case I64: return 1;
-    case F32: return 4;
-    case F64: return 8;
-    case FUNCREF: return 0;
-    case ANYREF: return 0;
-    default: assert(false);
+    case I32:
+      return 1;
+    case I64:
+      return 1;
+    case F32:
+      return 4;
+    case F64:
+      return 8;
+    case FUNCREF:
+      return 0;
+    case ANYREF:
+      return 0;
+    default:
+      assert(false);
   }
 }
 
 void encode_const_zero(char*& ptr, const ValType* type) {
   switch (type->kind()) {
-    case I32: *ptr++ = 0x41; break;
-    case I64: *ptr++ = 0x42; break;
-    case F32: *ptr++ = 0x43; break;
-    case F64: *ptr++ = 0x44; break;
-    case FUNCREF: *ptr++ = 0xd0; break;
-    case ANYREF: *ptr++ = 0xd0; break;
-    default: assert(false);
+    case I32:
+      *ptr++ = 0x41;
+      break;
+    case I64:
+      *ptr++ = 0x42;
+      break;
+    case F32:
+      *ptr++ = 0x43;
+      break;
+    case F64:
+      *ptr++ = 0x44;
+      break;
+    case FUNCREF:
+      *ptr++ = 0xd0;
+      break;
+    case ANYREF:
+      *ptr++ = 0xd0;
+      break;
+    default:
+      assert(false);
   }
-  for (int i = 0; i < zero_size(type); ++i) *ptr++ = 0;
+  for (int i = 0; i < zero_size(type); ++i)
+    *ptr++ = 0;
 }
-
 
 auto wrapper(const FuncType* type) -> vec<byte_t> {
   auto in_arity = type->params().size();
@@ -97,10 +132,10 @@ auto wrapper(const FuncType* type) -> vec<byte_t> {
 
   encode_header(ptr);
 
-  *ptr++ = 0x01;  // type section
+  *ptr++ = 0x01;                                  // type section
   encode_size32(ptr, 12 + in_arity + out_arity);  // size
-  *ptr++ = 1;  // length
-  *ptr++ = 0x60;  // function
+  *ptr++ = 1;                                     // length
+  *ptr++ = 0x60;                                  // function
   encode_size32(ptr, in_arity);
   for (size_t i = 0; i < in_arity; ++i) {
     encode_valtype(ptr, type->params()[i].get());
@@ -111,19 +146,19 @@ auto wrapper(const FuncType* type) -> vec<byte_t> {
   }
 
   *ptr++ = 0x02;  // import section
-  *ptr++ = 5;  // size
-  *ptr++ = 1;  // length
-  *ptr++ = 0;  // module length
-  *ptr++ = 0;  // name length
+  *ptr++ = 5;     // size
+  *ptr++ = 1;     // length
+  *ptr++ = 0;     // module length
+  *ptr++ = 0;     // name length
   *ptr++ = 0x00;  // func
-  *ptr++ = 0;  // type index
+  *ptr++ = 0;     // type index
 
   *ptr++ = 0x07;  // export section
-  *ptr++ = 4;  // size
-  *ptr++ = 1;  // length
-  *ptr++ = 0;  // name length
+  *ptr++ = 4;     // size
+  *ptr++ = 1;     // length
+  *ptr++ = 0;     // name length
   *ptr++ = 0x00;  // func
-  *ptr++ = 0;  // func index
+  *ptr++ = 0;     // func index
 
   assert(ptr - binary.get() == size);
   return binary;
@@ -136,25 +171,24 @@ auto wrapper(const GlobalType* type) -> vec<byte_t> {
 
   encode_header(ptr);
 
-  *ptr++ = 0x06;  // global section
+  *ptr++ = 0x06;                                       // global section
   encode_size32(ptr, 5 + zero_size(type->content()));  // size
-  *ptr++ = 1;  // length
+  *ptr++ = 1;                                          // length
   encode_valtype(ptr, type->content());
   *ptr++ = (type->mutability() == VAR);
   encode_const_zero(ptr, type->content());
   *ptr++ = 0x0b;  // end
 
   *ptr++ = 0x07;  // export section
-  *ptr++ = 4;  // size
-  *ptr++ = 1;  // length
-  *ptr++ = 0;  // name length
+  *ptr++ = 4;     // size
+  *ptr++ = 1;     // length
+  *ptr++ = 0;     // name length
   *ptr++ = 0x03;  // global
-  *ptr++ = 0;  // func index
+  *ptr++ = 0;     // func index
 
   assert(ptr - binary.get() == size);
   return binary;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Decoding
@@ -189,7 +223,6 @@ void u32_skip(const byte_t*& pos) {
   bin::u32(pos);
 }
 
-
 // Names
 
 auto name(const byte_t*& pos) -> Name {
@@ -206,17 +239,22 @@ void name_skip(const byte_t*& pos) {
   pos += size;
 }
 
-
 // Types
 
 auto valtype(const byte_t*& pos) -> own<wasm::ValType> {
   switch (*pos++) {
-    case 0x7f: return ValType::make(I32);
-    case 0x7e: return ValType::make(I64);
-    case 0x7d: return ValType::make(F32);
-    case 0x7c: return ValType::make(F64);
-    case 0x70: return ValType::make(FUNCREF);
-    case 0x6f: return ValType::make(ANYREF);
+    case 0x7f:
+      return ValType::make(I32);
+    case 0x7e:
+      return ValType::make(I64);
+    case 0x7d:
+      return ValType::make(F32);
+    case 0x7c:
+      return ValType::make(F64);
+    case 0x70:
+      return ValType::make(FUNCREF);
+    case 0x6f:
+      return ValType::make(ANYREF);
     default:
       // TODO(wasm+): support new value types
       assert(false);
@@ -241,7 +279,8 @@ auto limits(const byte_t*& pos) -> Limits {
 auto stacktype(const byte_t*& pos) -> ownvec<ValType> {
   size_t size = bin::u32(pos);
   auto v = ownvec<ValType>::make_uninitialized(size);
-  for (uint32_t i = 0; i < size; ++i) v[i] = bin::valtype(pos);
+  for (uint32_t i = 0; i < size; ++i)
+    v[i] = bin::valtype(pos);
   return v;
 }
 
@@ -270,7 +309,6 @@ auto memorytype(const byte_t*& pos) -> own<MemoryType> {
   return MemoryType::make(limits);
 }
 
-
 void mutability_skip(const byte_t*& pos) {
   ++pos;
 }
@@ -278,7 +316,8 @@ void mutability_skip(const byte_t*& pos) {
 void limits_skip(const byte_t*& pos) {
   auto tag = *pos++;
   bin::u32_skip(pos);
-  if ((tag & 0x01) != 0) bin::u32_skip(pos);
+  if ((tag & 0x01) != 0)
+    bin::u32_skip(pos);
 }
 
 void valtype_skip(const byte_t*& pos) {
@@ -300,14 +339,13 @@ void memorytype_skip(const byte_t*& pos) {
   bin::limits_skip(pos);
 }
 
-
 // Expressions
 
 void expr_skip(const byte_t*& pos) {
   switch (*pos++ & 0xff) {
-    case 0x41:  // i32.const
-    case 0x42:  // i64.const
-    case 0x23:  // get_global
+    case 0x41:    // i32.const
+    case 0x42:    // i64.const
+    case 0x23:    // get_global
     case 0xd2: {  // ref.func
       bin::u32_skip(pos);
     } break;
@@ -325,7 +363,6 @@ void expr_skip(const byte_t*& pos) {
   }
   ++pos;  // end
 }
-
 
 // Sections
 
@@ -346,7 +383,8 @@ auto section(const vec<byte_t>& binary, bin::sec_t sec) -> const byte_t* {
     auto size = bin::u32(pos);
     pos += size;
   }
-  if (pos == end) return nullptr;
+  if (pos == end)
+    return nullptr;
   bin::u32_skip(pos);
   return pos;
 }
@@ -359,18 +397,19 @@ auto section_end(const vec<byte_t>& binary, bin::sec_t sec) -> const byte_t* {
     auto size = bin::u32(pos);
     pos += size;
   }
-  if (pos == end) return nullptr;
+  if (pos == end)
+    return nullptr;
   ++pos;
   auto size = bin::u32(pos);
   return pos + size;
 }
 
-
 // Type section
 
 auto types(const vec<byte_t>& binary) -> ownvec<FuncType> {
   auto pos = bin::section(binary, SEC_TYPE);
-  if (pos == nullptr) return ownvec<FuncType>::make();
+  if (pos == nullptr)
+    return ownvec<FuncType>::make();
   size_t size = bin::u32(pos);
   // TODO(wasm+): support new deftypes
   auto v = ownvec<FuncType>::make_uninitialized(size);
@@ -381,14 +420,13 @@ auto types(const vec<byte_t>& binary) -> ownvec<FuncType> {
   return v;
 }
 
-
 // Import section
 
-auto imports(
-  const vec<byte_t>& binary, const ownvec<FuncType>& types
-) -> ownvec<ImportType> {
+auto imports(const vec<byte_t>& binary, const ownvec<FuncType>& types)
+    -> ownvec<ImportType> {
   auto pos = bin::section(binary, SEC_IMPORT);
-  if (pos == nullptr) return ownvec<ImportType>::make();
+  if (pos == nullptr)
+    return ownvec<ImportType>::make();
   size_t size = bin::u32(pos);
   auto v = ownvec<ImportType>::make_uninitialized(size);
   for (uint32_t i = 0; i < size; ++i) {
@@ -396,14 +434,23 @@ auto imports(
     auto name = bin::name(pos);
     own<ExternType> type;
     switch (*pos++) {
-      case 0x00: type = types[bin::u32(pos)]->copy(); break;
-      case 0x01: type = bin::tabletype(pos); break;
-      case 0x02: type = bin::memorytype(pos); break;
-      case 0x03: type = bin::globaltype(pos); break;
-      default: assert(false);
+      case 0x00:
+        type = types[bin::u32(pos)]->copy();
+        break;
+      case 0x01:
+        type = bin::tabletype(pos);
+        break;
+      case 0x02:
+        type = bin::memorytype(pos);
+        break;
+      case 0x03:
+        type = bin::globaltype(pos);
+        break;
+      default:
+        assert(false);
     }
-    v[i] = ImportType::make(
-      std::move(module), std::move(name), std::move(type));
+    v[i] =
+        ImportType::make(std::move(module), std::move(name), std::move(type));
   }
   assert(pos = bin::section_end(binary, SEC_IMPORT));
   return v;
@@ -412,22 +459,21 @@ auto imports(
 auto count(const ownvec<ImportType>& imports, ExternKind kind) -> uint32_t {
   uint32_t n = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
-    if (imports[i]->type()->kind() == kind) ++n;
+    if (imports[i]->type()->kind() == kind)
+      ++n;
   }
   return n;
 }
 
-
 // Function section
 
-auto funcs(
-  const vec<byte_t>& binary,
-  const ownvec<ImportType>& imports, const ownvec<FuncType>& types
-) -> ownvec<FuncType> {
+auto funcs(const vec<byte_t>& binary,
+           const ownvec<ImportType>& imports,
+           const ownvec<FuncType>& types) -> ownvec<FuncType> {
   auto pos = bin::section(binary, SEC_FUNC);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = ownvec<FuncType>::make_uninitialized(
-    size + count(imports, EXTERN_FUNC));
+  auto v =
+      ownvec<FuncType>::make_uninitialized(size + count(imports, EXTERN_FUNC));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto et = imports[i]->type();
@@ -444,16 +490,14 @@ auto funcs(
   return v;
 }
 
-
 // Global section
 
-auto globals(
-  const vec<byte_t>& binary, const ownvec<ImportType>& imports
-) -> ownvec<GlobalType> {
+auto globals(const vec<byte_t>& binary, const ownvec<ImportType>& imports)
+    -> ownvec<GlobalType> {
   auto pos = bin::section(binary, SEC_GLOBAL);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
   auto v = ownvec<GlobalType>::make_uninitialized(
-    size + count(imports, EXTERN_GLOBAL));
+      size + count(imports, EXTERN_GLOBAL));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto et = imports[i]->type();
@@ -471,16 +515,14 @@ auto globals(
   return v;
 }
 
-
 // Table section
 
-auto tables(
-  const vec<byte_t>& binary, const ownvec<ImportType>& imports
-) -> ownvec<TableType> {
+auto tables(const vec<byte_t>& binary, const ownvec<ImportType>& imports)
+    -> ownvec<TableType> {
   auto pos = bin::section(binary, SEC_TABLE);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = ownvec<TableType>::make_uninitialized(
-    size + count(imports, EXTERN_TABLE));
+  auto v = ownvec<TableType>::make_uninitialized(size +
+                                                 count(imports, EXTERN_TABLE));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto et = imports[i]->type();
@@ -497,16 +539,14 @@ auto tables(
   return v;
 }
 
-
 // Memory section
 
-auto memories(
-  const vec<byte_t>& binary, const ownvec<ImportType>& imports
-) -> ownvec<MemoryType> {
+auto memories(const vec<byte_t>& binary, const ownvec<ImportType>& imports)
+    -> ownvec<MemoryType> {
   auto pos = bin::section(binary, SEC_MEMORY);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
   auto v = ownvec<MemoryType>::make_uninitialized(
-    size + count(imports, EXTERN_MEMORY));
+      size + count(imports, EXTERN_MEMORY));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto et = imports[i]->type();
@@ -523,15 +563,16 @@ auto memories(
   return v;
 }
 
-
 // Export section
 
 auto exports(const vec<byte_t>& binary,
-  const ownvec<FuncType>& funcs, const ownvec<GlobalType>& globals,
-  const ownvec<TableType>& tables, const ownvec<MemoryType>& memories
-) -> ownvec<ExportType> {
+             const ownvec<FuncType>& funcs,
+             const ownvec<GlobalType>& globals,
+             const ownvec<TableType>& tables,
+             const ownvec<MemoryType>& memories) -> ownvec<ExportType> {
   auto pos = bin::section(binary, SEC_EXPORT);
-  if (pos == nullptr) return ownvec<ExportType>::make();
+  if (pos == nullptr)
+    return ownvec<ExportType>::make();
   size_t size = bin::u32(pos);
   auto exports = ownvec<ExportType>::make_uninitialized(size);
   for (uint32_t i = 0; i < size; ++i) {
@@ -540,11 +581,20 @@ auto exports(const vec<byte_t>& binary,
     auto index = bin::u32(pos);
     own<ExternType> type;
     switch (tag) {
-      case 0x00: type = funcs[index]->copy(); break;
-      case 0x01: type = tables[index]->copy(); break;
-      case 0x02: type = memories[index]->copy(); break;
-      case 0x03: type = globals[index]->copy(); break;
-      default: assert(false);
+      case 0x00:
+        type = funcs[index]->copy();
+        break;
+      case 0x01:
+        type = tables[index]->copy();
+        break;
+      case 0x02:
+        type = memories[index]->copy();
+        break;
+      case 0x03:
+        type = globals[index]->copy();
+        break;
+      default:
+        assert(false);
     }
     exports[i] = ExportType::make(std::move(name), std::move(type));
   }

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -1,7 +1,6 @@
+#include "wasm-v8.cc"
 #include "wasm.h"
 #include "wasm.hh"
-
-#include "wasm-v8.cc"
 
 using namespace wasm;
 
@@ -14,7 +13,7 @@ extern "C" {
 
 extern "C++" {
 
-template<class T>
+template <class T>
 struct borrowed_vec {
   vec<T> it;
   borrowed_vec(vec<T>&& v) : it(std::move(v)) {}
@@ -24,173 +23,163 @@ struct borrowed_vec {
 
 }  // extern "C++"
 
-
-#define WASM_DEFINE_OWN(name, Name) \
-  struct wasm_##name##_t : Name {}; \
-  \
-  void wasm_##name##_delete(wasm_##name##_t* x) { \
-    delete x; \
-  } \
-  \
-  extern "C++" inline auto hide_##name(Name* x) -> wasm_##name##_t* { \
-    return static_cast<wasm_##name##_t*>(x); \
-  } \
-  extern "C++" inline auto hide_##name(const Name* x) -> const wasm_##name##_t* { \
-    return static_cast<const wasm_##name##_t*>(x); \
-  } \
-  extern "C++" inline auto reveal_##name(wasm_##name##_t* x) -> Name* { \
-    return x; \
-  } \
-  extern "C++" inline auto reveal_##name(const wasm_##name##_t* x) -> const Name* { \
-    return x; \
-  } \
-  extern "C++" inline auto get_##name(own<Name>& x) -> wasm_##name##_t* { \
-    return hide_##name(x.get()); \
-  } \
-  extern "C++" inline auto get_##name(const own<Name>& x) -> const wasm_##name##_t* { \
-    return hide_##name(x.get()); \
-  } \
-  extern "C++" inline auto release_##name(own<Name>&& x) -> wasm_##name##_t* { \
-    return hide_##name(x.release()); \
-  } \
-  extern "C++" inline auto adopt_##name(wasm_##name##_t* x) -> own<Name> { \
-    return make_own(x); \
+#define WASM_DEFINE_OWN(name, Name)                                          \
+  struct wasm_##name##_t : Name {};                                          \
+                                                                             \
+  void wasm_##name##_delete(wasm_##name##_t* x) { delete x; }                \
+                                                                             \
+  extern "C++" inline auto hide_##name(Name* x)->wasm_##name##_t* {          \
+    return static_cast<wasm_##name##_t*>(x);                                 \
+  }                                                                          \
+  extern "C++" inline auto hide_##name(const Name* x)                        \
+      ->const wasm_##name##_t* {                                             \
+    return static_cast<const wasm_##name##_t*>(x);                           \
+  }                                                                          \
+  extern "C++" inline auto reveal_##name(wasm_##name##_t* x)->Name* {        \
+    return x;                                                                \
+  }                                                                          \
+  extern "C++" inline auto reveal_##name(const wasm_##name##_t* x)           \
+      ->const Name* {                                                        \
+    return x;                                                                \
+  }                                                                          \
+  extern "C++" inline auto get_##name(own<Name>& x)->wasm_##name##_t* {      \
+    return hide_##name(x.get());                                             \
+  }                                                                          \
+  extern "C++" inline auto get_##name(const own<Name>& x)                    \
+      ->const wasm_##name##_t* {                                             \
+    return hide_##name(x.get());                                             \
+  }                                                                          \
+  extern "C++" inline auto release_##name(own<Name>&& x)->wasm_##name##_t* { \
+    return hide_##name(x.release());                                         \
+  }                                                                          \
+  extern "C++" inline auto adopt_##name(wasm_##name##_t* x)->own<Name> {     \
+    return make_own(x);                                                      \
   }
-
 
 // Vectors
 
-#define WASM_DEFINE_VEC_BASE(name, Name, vec, ptr_or_none) \
-  static_assert( \
-    sizeof(wasm_##name##_vec_t) == sizeof(vec<Name>), \
-    "C/C++ incompatibility" \
-  ); \
-  static_assert( \
-    sizeof(wasm_##name##_t ptr_or_none) == sizeof(vec<Name>::elem_type), \
-    "C/C++ incompatibility" \
-  ); \
-  \
-  extern "C++" inline auto hide_##name##_vec(vec<Name>& v) \
-  -> wasm_##name##_vec_t* { \
-    return reinterpret_cast<wasm_##name##_vec_t*>(&v); \
-  } \
-  extern "C++" inline auto hide_##name##_vec(const vec<Name>& v) \
-  -> const wasm_##name##_vec_t* { \
-    return reinterpret_cast<const wasm_##name##_vec_t*>(&v); \
-  } \
-  extern "C++" inline auto hide_##name##_vec(vec<Name>::elem_type* v) \
-  -> wasm_##name##_t ptr_or_none* { \
-    return reinterpret_cast<wasm_##name##_t ptr_or_none*>(v); \
-  } \
-  extern "C++" inline auto hide_##name##_vec(const vec<Name>::elem_type* v) \
-  -> wasm_##name##_t ptr_or_none const* { \
-    return reinterpret_cast<wasm_##name##_t ptr_or_none const*>(v); \
-  } \
+#define WASM_DEFINE_VEC_BASE(name, Name, vec, ptr_or_none)                     \
+  static_assert(sizeof(wasm_##name##_vec_t) == sizeof(vec<Name>),              \
+                "C/C++ incompatibility");                                      \
+  static_assert(                                                               \
+      sizeof(wasm_##name##_t ptr_or_none) == sizeof(vec<Name>::elem_type),     \
+      "C/C++ incompatibility");                                                \
+                                                                               \
+  extern "C++" inline auto hide_##name##_vec(vec<Name>& v)                     \
+      ->wasm_##name##_vec_t* {                                                 \
+    return reinterpret_cast<wasm_##name##_vec_t*>(&v);                         \
+  }                                                                            \
+  extern "C++" inline auto hide_##name##_vec(const vec<Name>& v)               \
+      ->const wasm_##name##_vec_t* {                                           \
+    return reinterpret_cast<const wasm_##name##_vec_t*>(&v);                   \
+  }                                                                            \
+  extern "C++" inline auto hide_##name##_vec(vec<Name>::elem_type* v)          \
+      ->wasm_##name##_t ptr_or_none* {                                         \
+    return reinterpret_cast<wasm_##name##_t ptr_or_none*>(v);                  \
+  }                                                                            \
+  extern "C++" inline auto hide_##name##_vec(const vec<Name>::elem_type* v)    \
+      ->wasm_##name##_t ptr_or_none const* {                                   \
+    return reinterpret_cast<wasm_##name##_t ptr_or_none const*>(v);            \
+  }                                                                            \
   extern "C++" inline auto reveal_##name##_vec(wasm_##name##_t ptr_or_none* v) \
-  -> vec<Name>::elem_type* { \
-    return reinterpret_cast<vec<Name>::elem_type*>(v); \
-  } \
-  extern "C++" inline auto reveal_##name##_vec(wasm_##name##_t ptr_or_none const* v) \
-  -> const vec<Name>::elem_type* { \
-    return reinterpret_cast<const vec<Name>::elem_type*>(v); \
-  } \
-  extern "C++" inline auto get_##name##_vec(vec<Name>& v) \
-  -> wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2 = { v.size(), hide_##name##_vec(v.get()) }; \
-    return v2; \
-  } \
-  extern "C++" inline auto get_##name##_vec(const vec<Name>& v) \
-  -> const wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2 = { \
-      v.size(), const_cast<wasm_##name##_t ptr_or_none*>(hide_##name##_vec(v.get())) }; \
-    return v2; \
-  } \
-  extern "C++" inline auto release_##name##_vec(vec<Name>&& v) \
-  -> wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2 = { v.size(), hide_##name##_vec(v.release()) }; \
-    return v2; \
-  } \
-  extern "C++" inline auto adopt_##name##_vec(wasm_##name##_vec_t* v) \
-  -> vec<Name> { \
-    return vec<Name>::adopt(v->size, reveal_##name##_vec(v->data)); \
-  } \
-  extern "C++" inline auto borrow_##name##_vec(const wasm_##name##_vec_t* v) \
-  -> borrowed_vec<vec<Name>::elem_type> { \
-    return borrowed_vec<vec<Name>::elem_type>(vec<Name>::adopt(v->size, reveal_##name##_vec(v->data))); \
-  } \
-  \
-  void wasm_##name##_vec_new_uninitialized( \
-    wasm_##name##_vec_t* out, size_t size \
-  ) { \
-    *out = release_##name##_vec(vec<Name>::make_uninitialized(size)); \
-  } \
-  void wasm_##name##_vec_new_empty(wasm_##name##_vec_t* out) { \
-    wasm_##name##_vec_new_uninitialized(out, 0); \
-  } \
-  \
-  void wasm_##name##_vec_delete(wasm_##name##_vec_t* v) { \
-    adopt_##name##_vec(v); \
+      ->vec<Name>::elem_type* {                                                \
+    return reinterpret_cast<vec<Name>::elem_type*>(v);                         \
+  }                                                                            \
+  extern "C++" inline auto reveal_##name##_vec(                                \
+      wasm_##name##_t ptr_or_none const* v)                                    \
+      ->const vec<Name>::elem_type* {                                          \
+    return reinterpret_cast<const vec<Name>::elem_type*>(v);                   \
+  }                                                                            \
+  extern "C++" inline auto get_##name##_vec(vec<Name>& v)                      \
+      ->wasm_##name##_vec_t {                                                  \
+    wasm_##name##_vec_t v2 = {v.size(), hide_##name##_vec(v.get())};           \
+    return v2;                                                                 \
+  }                                                                            \
+  extern "C++" inline auto get_##name##_vec(const vec<Name>& v)                \
+      ->const wasm_##name##_vec_t {                                            \
+    wasm_##name##_vec_t v2 = {                                                 \
+        v.size(),                                                              \
+        const_cast<wasm_##name##_t ptr_or_none*>(hide_##name##_vec(v.get()))}; \
+    return v2;                                                                 \
+  }                                                                            \
+  extern "C++" inline auto release_##name##_vec(vec<Name>&& v)                 \
+      ->wasm_##name##_vec_t {                                                  \
+    wasm_##name##_vec_t v2 = {v.size(), hide_##name##_vec(v.release())};       \
+    return v2;                                                                 \
+  }                                                                            \
+  extern "C++" inline auto adopt_##name##_vec(wasm_##name##_vec_t* v)          \
+      ->vec<Name> {                                                            \
+    return vec<Name>::adopt(v->size, reveal_##name##_vec(v->data));            \
+  }                                                                            \
+  extern "C++" inline auto borrow_##name##_vec(const wasm_##name##_vec_t* v)   \
+      ->borrowed_vec<vec<Name>::elem_type> {                                   \
+    return borrowed_vec<vec<Name>::elem_type>(                                 \
+        vec<Name>::adopt(v->size, reveal_##name##_vec(v->data)));              \
+  }                                                                            \
+                                                                               \
+  void wasm_##name##_vec_new_uninitialized(wasm_##name##_vec_t* out,           \
+                                           size_t size) {                      \
+    *out = release_##name##_vec(vec<Name>::make_uninitialized(size));          \
+  }                                                                            \
+  void wasm_##name##_vec_new_empty(wasm_##name##_vec_t* out) {                 \
+    wasm_##name##_vec_new_uninitialized(out, 0);                               \
+  }                                                                            \
+                                                                               \
+  void wasm_##name##_vec_delete(wasm_##name##_vec_t* v) {                      \
+    adopt_##name##_vec(v);                                                     \
   }
 
 // Vectors with no ownership management of elements
-#define WASM_DEFINE_VEC_PLAIN(name, Name) \
-  WASM_DEFINE_VEC_BASE(name, Name, vec, ) \
-  \
-  void wasm_##name##_vec_new( \
-    wasm_##name##_vec_t* out, \
-    size_t size, \
-    const wasm_##name##_t data[] \
-  ) { \
-    auto v2 = vec<Name>::make_uninitialized(size); \
-    if (v2.size() != 0) { \
-      memcpy(v2.get(), data, size * sizeof(wasm_##name##_t)); \
-    } \
-    *out = release_##name##_vec(std::move(v2)); \
-  } \
-  \
-  void wasm_##name##_vec_copy( \
-    wasm_##name##_vec_t* out, wasm_##name##_vec_t* v \
-  ) { \
-    wasm_##name##_vec_new(out, v->size, v->data); \
+#define WASM_DEFINE_VEC_PLAIN(name, Name)                           \
+  WASM_DEFINE_VEC_BASE(name, Name, vec, )                           \
+                                                                    \
+  void wasm_##name##_vec_new(wasm_##name##_vec_t* out, size_t size, \
+                             const wasm_##name##_t data[]) {        \
+    auto v2 = vec<Name>::make_uninitialized(size);                  \
+    if (v2.size() != 0) {                                           \
+      memcpy(v2.get(), data, size * sizeof(wasm_##name##_t));       \
+    }                                                               \
+    *out = release_##name##_vec(std::move(v2));                     \
+  }                                                                 \
+                                                                    \
+  void wasm_##name##_vec_copy(wasm_##name##_vec_t* out,             \
+                              wasm_##name##_vec_t* v) {             \
+    wasm_##name##_vec_new(out, v->size, v->data);                   \
   }
 
 // Vectors that own their elements
-#define WASM_DEFINE_VEC_OWN(name, Name) \
-  WASM_DEFINE_VEC_BASE(name, Name, ownvec, *) \
-  \
-  void wasm_##name##_vec_new( \
-    wasm_##name##_vec_t* out, \
-    size_t size, \
-    wasm_##name##_t* const data[] \
-  ) { \
-    auto v2 = ownvec<Name>::make_uninitialized(size); \
-    for (size_t i = 0; i < v2.size(); ++i) { \
-      v2[i] = adopt_##name(data[i]); \
-    } \
-    *out = release_##name##_vec(std::move(v2)); \
-  } \
-  \
-  void wasm_##name##_vec_copy( \
-    wasm_##name##_vec_t* out, wasm_##name##_vec_t* v \
-  ) { \
-    auto v2 = ownvec<Name>::make_uninitialized(v->size); \
-    for (size_t i = 0; i < v2.size(); ++i) { \
-      v2[i] = adopt_##name(wasm_##name##_copy(v->data[i])); \
-    } \
-    *out = release_##name##_vec(std::move(v2)); \
+#define WASM_DEFINE_VEC_OWN(name, Name)                             \
+  WASM_DEFINE_VEC_BASE(name, Name, ownvec, *)                       \
+                                                                    \
+  void wasm_##name##_vec_new(wasm_##name##_vec_t* out, size_t size, \
+                             wasm_##name##_t* const data[]) {       \
+    auto v2 = ownvec<Name>::make_uninitialized(size);               \
+    for (size_t i = 0; i < v2.size(); ++i) {                        \
+      v2[i] = adopt_##name(data[i]);                                \
+    }                                                               \
+    *out = release_##name##_vec(std::move(v2));                     \
+  }                                                                 \
+                                                                    \
+  void wasm_##name##_vec_copy(wasm_##name##_vec_t* out,             \
+                              wasm_##name##_vec_t* v) {             \
+    auto v2 = ownvec<Name>::make_uninitialized(v->size);            \
+    for (size_t i = 0; i < v2.size(); ++i) {                        \
+      v2[i] = adopt_##name(wasm_##name##_copy(v->data[i]));         \
+    }                                                               \
+    *out = release_##name##_vec(std::move(v2));                     \
   }
 
 extern "C++" {
-template<class T>
-inline auto is_empty(T* p) -> bool { return !p; }
+template <class T>
+inline auto is_empty(T* p) -> bool {
+  return !p;
 }
-
+}
 
 // Byte vectors
 
 using byte = byte_t;
 WASM_DEFINE_VEC_PLAIN(byte, byte)
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
@@ -202,7 +191,6 @@ WASM_DEFINE_OWN(config, Config)
 wasm_config_t* wasm_config_new() {
   return release_config(Config::make());
 }
-
 
 // Engine
 
@@ -216,7 +204,6 @@ wasm_engine_t* wasm_engine_new_with_config(wasm_config_t* config) {
   return release_engine(Engine::make(adopt_config(config)));
 }
 
-
 // Stores
 
 WASM_DEFINE_OWN(store, Store)
@@ -225,29 +212,29 @@ wasm_store_t* wasm_store_new(wasm_engine_t* engine) {
   return release_store(Store::make(engine));
 };
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // Type Representations
 
 // Type attributes
 
-extern "C++" inline auto hide_mutability(Mutability mutability) -> wasm_mutability_t {
+extern "C++" inline auto hide_mutability(Mutability mutability)
+    -> wasm_mutability_t {
   return static_cast<wasm_mutability_t>(mutability);
 }
 
-extern "C++" inline auto reveal_mutability(wasm_mutability_t mutability) -> Mutability {
+extern "C++" inline auto reveal_mutability(wasm_mutability_t mutability)
+    -> Mutability {
   return static_cast<Mutability>(mutability);
 }
 
-
-extern "C++" inline auto hide_limits(const Limits& limits) -> const wasm_limits_t* {
+extern "C++" inline auto hide_limits(const Limits& limits)
+    -> const wasm_limits_t* {
   return reinterpret_cast<const wasm_limits_t*>(&limits);
 }
 
 extern "C++" inline auto reveal_limits(wasm_limits_t limits) -> Limits {
   return Limits(limits.min, limits.max);
 }
-
 
 extern "C++" inline auto hide_valkind(ValKind kind) -> wasm_valkind_t {
   return static_cast<wasm_valkind_t>(kind);
@@ -257,27 +244,24 @@ extern "C++" inline auto reveal_valkind(wasm_valkind_t kind) -> ValKind {
   return static_cast<ValKind>(kind);
 }
 
-
 extern "C++" inline auto hide_externkind(ExternKind kind) -> wasm_externkind_t {
   return static_cast<wasm_externkind_t>(kind);
 }
 
-extern "C++" inline auto reveal_externkind(wasm_externkind_t kind) -> ExternKind {
+extern "C++" inline auto reveal_externkind(wasm_externkind_t kind)
+    -> ExternKind {
   return static_cast<ExternKind>(kind);
 }
 
-
-
 // Generic
 
-#define WASM_DEFINE_TYPE(name, Name) \
-  WASM_DEFINE_OWN(name, Name) \
-  WASM_DEFINE_VEC_OWN(name, Name) \
-  \
+#define WASM_DEFINE_TYPE(name, Name)                        \
+  WASM_DEFINE_OWN(name, Name)                               \
+  WASM_DEFINE_VEC_OWN(name, Name)                           \
+                                                            \
   wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* t) { \
-    return release_##name(t->copy()); \
+    return release_##name(t->copy());                       \
   }
-
 
 // Value Types
 
@@ -291,16 +275,14 @@ wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t* t) {
   return hide_valkind(t->kind());
 }
 
-
 // Function Types
 
 WASM_DEFINE_TYPE(functype, FuncType)
 
-wasm_functype_t* wasm_functype_new(
-  wasm_valtype_vec_t* params, wasm_valtype_vec_t* results
-) {
+wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t* params,
+                                   wasm_valtype_vec_t* results) {
   return release_functype(
-    FuncType::make(adopt_valtype_vec(params), adopt_valtype_vec(results)));
+      FuncType::make(adopt_valtype_vec(params), adopt_valtype_vec(results)));
 }
 
 const wasm_valtype_vec_t* wasm_functype_params(const wasm_functype_t* ft) {
@@ -311,18 +293,14 @@ const wasm_valtype_vec_t* wasm_functype_results(const wasm_functype_t* ft) {
   return hide_valtype_vec(ft->results());
 }
 
-
 // Global Types
 
 WASM_DEFINE_TYPE(globaltype, GlobalType)
 
-wasm_globaltype_t* wasm_globaltype_new(
-  wasm_valtype_t* content, wasm_mutability_t mutability
-) {
-  return release_globaltype(GlobalType::make(
-    adopt_valtype(content),
-    reveal_mutability(mutability)
-  ));
+wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t* content,
+                                       wasm_mutability_t mutability) {
+  return release_globaltype(
+      GlobalType::make(adopt_valtype(content), reveal_mutability(mutability)));
 }
 
 const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t* gt) {
@@ -333,15 +311,14 @@ wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t* gt) {
   return hide_mutability(gt->mutability());
 }
 
-
 // Table Types
 
 WASM_DEFINE_TYPE(tabletype, TableType)
 
-wasm_tabletype_t* wasm_tabletype_new(
-  wasm_valtype_t* element, const wasm_limits_t* limits
-) {
-  return release_tabletype(TableType::make(adopt_valtype(element), reveal_limits(*limits)));
+wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t* element,
+                                     const wasm_limits_t* limits) {
+  return release_tabletype(
+      TableType::make(adopt_valtype(element), reveal_limits(*limits)));
 }
 
 const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t* tt) {
@@ -351,7 +328,6 @@ const wasm_valtype_t* wasm_tabletype_element(const wasm_tabletype_t* tt) {
 const wasm_limits_t* wasm_tabletype_limits(const wasm_tabletype_t* tt) {
   return hide_limits(tt->limits());
 }
-
 
 // Memory Types
 
@@ -364,7 +340,6 @@ wasm_memorytype_t* wasm_memorytype_new(const wasm_limits_t* limits) {
 const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t* mt) {
   return hide_limits(mt->limits());
 }
-
 
 // Extern Types
 
@@ -388,78 +363,80 @@ wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t* mt) {
 }
 
 const wasm_externtype_t* wasm_functype_as_externtype_const(
-  const wasm_functype_t* ft
-) {
+    const wasm_functype_t* ft) {
   return hide_externtype(static_cast<const ExternType*>(ft));
 }
 const wasm_externtype_t* wasm_globaltype_as_externtype_const(
-  const wasm_globaltype_t* gt
-) {
+    const wasm_globaltype_t* gt) {
   return hide_externtype(static_cast<const ExternType*>(gt));
 }
 const wasm_externtype_t* wasm_tabletype_as_externtype_const(
-  const wasm_tabletype_t* tt
-) {
+    const wasm_tabletype_t* tt) {
   return hide_externtype(static_cast<const ExternType*>(tt));
 }
 const wasm_externtype_t* wasm_memorytype_as_externtype_const(
-  const wasm_memorytype_t* mt
-) {
+    const wasm_memorytype_t* mt) {
   return hide_externtype(static_cast<const ExternType*>(mt));
 }
 
 wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t* et) {
   return et->kind() == EXTERN_FUNC
-    ? hide_functype(static_cast<FuncType*>(reveal_externtype(et))) : nullptr;
+             ? hide_functype(static_cast<FuncType*>(reveal_externtype(et)))
+             : nullptr;
 }
 wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t* et) {
   return et->kind() == EXTERN_GLOBAL
-    ? hide_globaltype(static_cast<GlobalType*>(reveal_externtype(et))) : nullptr;
+             ? hide_globaltype(static_cast<GlobalType*>(reveal_externtype(et)))
+             : nullptr;
 }
 wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t* et) {
   return et->kind() == EXTERN_TABLE
-    ? hide_tabletype(static_cast<TableType*>(reveal_externtype(et))) : nullptr;
+             ? hide_tabletype(static_cast<TableType*>(reveal_externtype(et)))
+             : nullptr;
 }
 wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t* et) {
   return et->kind() == EXTERN_MEMORY
-    ? hide_memorytype(static_cast<MemoryType*>(reveal_externtype(et))) : nullptr;
+             ? hide_memorytype(static_cast<MemoryType*>(reveal_externtype(et)))
+             : nullptr;
 }
 
 const wasm_functype_t* wasm_externtype_as_functype_const(
-  const wasm_externtype_t* et
-) {
-  return et->kind() == EXTERN_FUNC
-    ? hide_functype(static_cast<const FuncType*>(reveal_externtype(et))) : nullptr;
+    const wasm_externtype_t* et) {
+  return et->kind() == EXTERN_FUNC ? hide_functype(static_cast<const FuncType*>(
+                                         reveal_externtype(et)))
+                                   : nullptr;
 }
 const wasm_globaltype_t* wasm_externtype_as_globaltype_const(
-  const wasm_externtype_t* et
-) {
+    const wasm_externtype_t* et) {
   return et->kind() == EXTERN_GLOBAL
-    ? hide_globaltype(static_cast<const GlobalType*>(reveal_externtype(et))) : nullptr;
+             ? hide_globaltype(
+                   static_cast<const GlobalType*>(reveal_externtype(et)))
+             : nullptr;
 }
 const wasm_tabletype_t* wasm_externtype_as_tabletype_const(
-  const wasm_externtype_t* et
-) {
+    const wasm_externtype_t* et) {
   return et->kind() == EXTERN_TABLE
-    ? hide_tabletype(static_cast<const TableType*>(reveal_externtype(et))) : nullptr;
+             ? hide_tabletype(
+                   static_cast<const TableType*>(reveal_externtype(et)))
+             : nullptr;
 }
 const wasm_memorytype_t* wasm_externtype_as_memorytype_const(
-  const wasm_externtype_t* et
-) {
+    const wasm_externtype_t* et) {
   return et->kind() == EXTERN_MEMORY
-    ? hide_memorytype(static_cast<const MemoryType*>(reveal_externtype(et))) : nullptr;
+             ? hide_memorytype(
+                   static_cast<const MemoryType*>(reveal_externtype(et)))
+             : nullptr;
 }
-
 
 // Import Types
 
 WASM_DEFINE_TYPE(importtype, ImportType)
 
-wasm_importtype_t* wasm_importtype_new(
-  wasm_name_t* module, wasm_name_t* name, wasm_externtype_t* type
-) {
-  return release_importtype(
-    ImportType::make(adopt_byte_vec(module), adopt_byte_vec(name), adopt_externtype(type)));
+wasm_importtype_t* wasm_importtype_new(wasm_name_t* module,
+                                       wasm_name_t* name,
+                                       wasm_externtype_t* type) {
+  return release_importtype(ImportType::make(
+      adopt_byte_vec(module), adopt_byte_vec(name), adopt_externtype(type)));
 }
 
 const wasm_name_t* wasm_importtype_module(const wasm_importtype_t* it) {
@@ -474,16 +451,14 @@ const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t* it) {
   return hide_externtype(it->type());
 }
 
-
 // Export Types
 
 WASM_DEFINE_TYPE(exporttype, ExportType)
 
-wasm_exporttype_t* wasm_exporttype_new(
-  wasm_name_t* name, wasm_externtype_t* type
-) {
+wasm_exporttype_t* wasm_exporttype_new(wasm_name_t* name,
+                                       wasm_externtype_t* type) {
   return release_exporttype(
-    ExportType::make(adopt_byte_vec(name), adopt_externtype(type)));
+      ExportType::make(adopt_byte_vec(name), adopt_externtype(type)));
 }
 
 const wasm_name_t* wasm_exporttype_name(const wasm_exporttype_t* et) {
@@ -494,105 +469,130 @@ const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t* et) {
   return hide_externtype(et->type());
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Values
 
 // References
 
-#define WASM_DEFINE_REF_BASE(name, Name) \
-  WASM_DEFINE_OWN(name, Name) \
-  \
-  wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t* t) { \
-    return release_##name(t->copy()); \
-  } \
-  \
-  bool wasm_##name##_same(const wasm_##name##_t* t1, const wasm_##name##_t* t2) { \
-    return t1->same(t2); \
-  } \
-  \
-  void* wasm_##name##_get_host_info(const wasm_##name##_t* r) { \
-    return r->get_host_info(); \
-  } \
+#define WASM_DEFINE_REF_BASE(name, Name)                             \
+  WASM_DEFINE_OWN(name, Name)                                        \
+                                                                     \
+  wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t* t) {    \
+    return release_##name(t->copy());                                \
+  }                                                                  \
+                                                                     \
+  bool wasm_##name##_same(const wasm_##name##_t* t1,                 \
+                          const wasm_##name##_t* t2) {               \
+    return t1->same(t2);                                             \
+  }                                                                  \
+                                                                     \
+  void* wasm_##name##_get_host_info(const wasm_##name##_t* r) {      \
+    return r->get_host_info();                                       \
+  }                                                                  \
   void wasm_##name##_set_host_info(wasm_##name##_t* r, void* info) { \
-    r->set_host_info(info); \
-  } \
-  void wasm_##name##_set_host_info_with_finalizer( \
-    wasm_##name##_t* r, void* info, void (*finalizer)(void*) \
-  ) { \
-    r->set_host_info(info, finalizer); \
+    r->set_host_info(info);                                          \
+  }                                                                  \
+  void wasm_##name##_set_host_info_with_finalizer(                   \
+      wasm_##name##_t* r, void* info, void (*finalizer)(void*)) {    \
+    r->set_host_info(info, finalizer);                               \
   }
 
-#define WASM_DEFINE_REF(name, Name) \
-  WASM_DEFINE_REF_BASE(name, Name) \
-  \
-  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t* r) { \
-    return hide_ref(static_cast<Ref*>(reveal_##name(r))); \
-  } \
-  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t* r) { \
-    return hide_##name(static_cast<Name*>(reveal_ref(r))); \
-  } \
-  \
+#define WASM_DEFINE_REF(name, Name)                                        \
+  WASM_DEFINE_REF_BASE(name, Name)                                         \
+                                                                           \
+  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t* r) {                   \
+    return hide_ref(static_cast<Ref*>(reveal_##name(r)));                  \
+  }                                                                        \
+  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t* r) {                     \
+    return hide_##name(static_cast<Name*>(reveal_ref(r)));                 \
+  }                                                                        \
+                                                                           \
   const wasm_ref_t* wasm_##name##_as_ref_const(const wasm_##name##_t* r) { \
-    return hide_ref(static_cast<const Ref*>(reveal_##name(r))); \
-  } \
+    return hide_ref(static_cast<const Ref*>(reveal_##name(r)));            \
+  }                                                                        \
   const wasm_##name##_t* wasm_ref_as_##name##_const(const wasm_ref_t* r) { \
-    return hide_##name(static_cast<const Name*>(reveal_ref(r))); \
+    return hide_##name(static_cast<const Name*>(reveal_ref(r)));           \
   }
 
 #define WASM_DEFINE_SHARABLE_REF(name, Name) \
-  WASM_DEFINE_REF(name, Name) \
+  WASM_DEFINE_REF(name, Name)                \
   WASM_DEFINE_OWN(shared_##name, Shared<Name>)
 
-
 WASM_DEFINE_REF_BASE(ref, Ref)
-
 
 // Values
 
 extern "C++" {
 
 inline auto is_empty(wasm_val_t v) -> bool {
- return !is_ref(reveal_valkind(v.kind)) || !v.of.ref;
+  return !is_ref(reveal_valkind(v.kind)) || !v.of.ref;
 }
 
 inline auto hide_val(Val v) -> wasm_val_t {
-  wasm_val_t v2 = { hide_valkind(v.kind()) };
+  wasm_val_t v2 = {hide_valkind(v.kind())};
   switch (v.kind()) {
-    case I32: v2.of.i32 = v.i32(); break;
-    case I64: v2.of.i64 = v.i64(); break;
-    case F32: v2.of.f32 = v.f32(); break;
-    case F64: v2.of.f64 = v.f64(); break;
+    case I32:
+      v2.of.i32 = v.i32();
+      break;
+    case I64:
+      v2.of.i64 = v.i64();
+      break;
+    case F32:
+      v2.of.f32 = v.f32();
+      break;
+    case F64:
+      v2.of.f64 = v.f64();
+      break;
     case ANYREF:
-    case FUNCREF: v2.of.ref = hide_ref(v.ref()); break;
-    default: assert(false);
+    case FUNCREF:
+      v2.of.ref = hide_ref(v.ref());
+      break;
+    default:
+      assert(false);
   }
   return v2;
 }
 
 inline auto release_val(Val v) -> wasm_val_t {
-  wasm_val_t v2 = { hide_valkind(v.kind()) };
+  wasm_val_t v2 = {hide_valkind(v.kind())};
   switch (v.kind()) {
-    case I32: v2.of.i32 = v.i32(); break;
-    case I64: v2.of.i64 = v.i64(); break;
-    case F32: v2.of.f32 = v.f32(); break;
-    case F64: v2.of.f64 = v.f64(); break;
+    case I32:
+      v2.of.i32 = v.i32();
+      break;
+    case I64:
+      v2.of.i64 = v.i64();
+      break;
+    case F32:
+      v2.of.f32 = v.f32();
+      break;
+    case F64:
+      v2.of.f64 = v.f64();
+      break;
     case ANYREF:
-    case FUNCREF: v2.of.ref = release_ref(v.release_ref()); break;
-    default: assert(false);
+    case FUNCREF:
+      v2.of.ref = release_ref(v.release_ref());
+      break;
+    default:
+      assert(false);
   }
   return v2;
 }
 
 inline auto adopt_val(wasm_val_t v) -> Val {
   switch (reveal_valkind(v.kind)) {
-    case I32: return Val(v.of.i32);
-    case I64: return Val(v.of.i64);
-    case F32: return Val(v.of.f32);
-    case F64: return Val(v.of.f64);
+    case I32:
+      return Val(v.of.i32);
+    case I64:
+      return Val(v.of.i64);
+    case F32:
+      return Val(v.of.f32);
+    case F64:
+      return Val(v.of.f64);
     case ANYREF:
-    case FUNCREF: return Val(adopt_ref(v.of.ref));
-    default: assert(false);
+    case FUNCREF:
+      return Val(adopt_ref(v.of.ref));
+    default:
+      assert(false);
   }
 }
 
@@ -600,31 +600,44 @@ struct borrowed_val {
   Val it;
   borrowed_val(Val&& v) : it(std::move(v)) {}
   borrowed_val(borrowed_val&& that) : it(std::move(that.it)) {}
-  ~borrowed_val() { if (it.is_ref()) it.release_ref().release(); }
+  ~borrowed_val() {
+    if (it.is_ref())
+      it.release_ref().release();
+  }
 };
 
 inline auto borrow_val(const wasm_val_t* v) -> borrowed_val {
   Val v2;
   switch (reveal_valkind(v->kind)) {
-    case I32: v2 = Val(v->of.i32); break;
-    case I64: v2 = Val(v->of.i64); break;
-    case F32: v2 = Val(v->of.f32); break;
-    case F64: v2 = Val(v->of.f64); break;
+    case I32:
+      v2 = Val(v->of.i32);
+      break;
+    case I64:
+      v2 = Val(v->of.i64);
+      break;
+    case F32:
+      v2 = Val(v->of.f32);
+      break;
+    case F64:
+      v2 = Val(v->of.f64);
+      break;
     case ANYREF:
-    case FUNCREF: v2 = Val(adopt_ref(v->of.ref)); break;
-    default: assert(false);
+    case FUNCREF:
+      v2 = Val(adopt_ref(v->of.ref));
+      break;
+    default:
+      assert(false);
   }
   return borrowed_val(std::move(v2));
 }
 
 }  // extern "C++"
 
-
 WASM_DEFINE_VEC_BASE(val, Val, vec, )
 
-void wasm_val_vec_new(
-  wasm_val_vec_t* out, size_t size, wasm_val_t const data[]
-) {
+void wasm_val_vec_new(wasm_val_vec_t* out,
+                      size_t size,
+                      wasm_val_t const data[]) {
   auto v2 = vec<Val>::make_uninitialized(size);
   for (size_t i = 0; i < v2.size(); ++i) {
     v2[i] = adopt_val(data[i]);
@@ -642,7 +655,6 @@ void wasm_val_vec_copy(wasm_val_vec_t* out, wasm_val_vec_t* v) {
   *out = release_val_vec(std::move(v2));
 }
 
-
 void wasm_val_delete(wasm_val_t* v) {
   if (is_ref(reveal_valkind(v->kind))) {
     adopt_ref(v->of.ref);
@@ -655,7 +667,6 @@ void wasm_val_copy(wasm_val_t* out, const wasm_val_t* v) {
     out->of.ref = v->of.ref ? release_ref(v->of.ref->copy()) : nullptr;
   }
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Objects
@@ -684,7 +695,6 @@ size_t wasm_frame_module_offset(const wasm_frame_t* frame) {
   return reveal_frame(frame)->module_offset();
 }
 
-
 // Traps
 
 WASM_DEFINE_REF(trap, Trap)
@@ -706,7 +716,6 @@ void wasm_trap_trace(const wasm_trap_t* trap, wasm_frame_vec_t* out) {
   *out = release_frame_vec(reveal_trap(trap)->trace());
 }
 
-
 // Foreign Objects
 
 WASM_DEFINE_REF(foreign, Foreign)
@@ -714,7 +723,6 @@ WASM_DEFINE_REF(foreign, Foreign)
 wasm_foreign_t* wasm_foreign_new(wasm_store_t* store) {
   return release_foreign(Foreign::make(store));
 }
-
 
 // Modules
 
@@ -725,23 +733,19 @@ bool wasm_module_validate(wasm_store_t* store, const wasm_byte_vec_t* binary) {
   return Module::validate(store, binary_.it);
 }
 
-wasm_module_t* wasm_module_new(
-  wasm_store_t* store, const wasm_byte_vec_t* binary
-) {
+wasm_module_t* wasm_module_new(wasm_store_t* store,
+                               const wasm_byte_vec_t* binary) {
   auto binary_ = borrow_byte_vec(binary);
   return release_module(Module::make(store, binary_.it));
 }
 
-
-void wasm_module_imports(
-  const wasm_module_t* module, wasm_importtype_vec_t* out
-) {
+void wasm_module_imports(const wasm_module_t* module,
+                         wasm_importtype_vec_t* out) {
   *out = release_importtype_vec(reveal_module(module)->imports());
 }
 
-void wasm_module_exports(
-  const wasm_module_t* module, wasm_exporttype_vec_t* out
-) {
+void wasm_module_exports(const wasm_module_t* module,
+                         wasm_exporttype_vec_t* out) {
   *out = release_exporttype_vec(reveal_module(module)->exports());
 }
 
@@ -749,9 +753,8 @@ void wasm_module_serialize(const wasm_module_t* module, wasm_byte_vec_t* out) {
   *out = release_byte_vec(reveal_module(module)->serialize());
 }
 
-wasm_module_t* wasm_module_deserialize(
-  wasm_store_t* store, const wasm_byte_vec_t* binary
-) {
+wasm_module_t* wasm_module_deserialize(wasm_store_t* store,
+                                       const wasm_byte_vec_t* binary) {
   auto binary_ = borrow_byte_vec(binary);
   return release_module(Module::deserialize(store, binary_.it));
 }
@@ -760,10 +763,10 @@ wasm_shared_module_t* wasm_module_share(const wasm_module_t* module) {
   return release_shared_module(reveal_module(module)->share());
 }
 
-wasm_module_t* wasm_module_obtain(wasm_store_t* store, const wasm_shared_module_t* shared) {
+wasm_module_t* wasm_module_obtain(wasm_store_t* store,
+                                  const wasm_shared_module_t* shared) {
   return release_module(Module::obtain(store, shared));
 }
-
 
 // Function Instances
 
@@ -782,35 +785,37 @@ struct wasm_callback_env_t {
   void (*finalizer)(void*);
 };
 
-auto wasm_callback_with_env(
-  void* env, const Val args[], Val results[]
-) -> own<Trap> {
+auto wasm_callback_with_env(void* env, const Val args[], Val results[])
+    -> own<Trap> {
   auto t = static_cast<wasm_callback_env_t*>(env);
-  return adopt_trap(t->callback(t->env, hide_val_vec(args), hide_val_vec(results)));
+  return adopt_trap(
+      t->callback(t->env, hide_val_vec(args), hide_val_vec(results)));
 }
 
 void wasm_callback_env_finalizer(void* env) {
   auto t = static_cast<wasm_callback_env_t*>(env);
-  if (t->finalizer) t->finalizer(t->env);
+  if (t->finalizer)
+    t->finalizer(t->env);
   delete t;
 }
 
 }  // extern "C++"
 
-wasm_func_t* wasm_func_new(
-  wasm_store_t* store, const wasm_functype_t* type,
-  wasm_func_callback_t callback
-) {
-  return release_func(Func::make(
-    store, type, wasm_callback, reinterpret_cast<void*>(callback)));
+wasm_func_t* wasm_func_new(wasm_store_t* store,
+                           const wasm_functype_t* type,
+                           wasm_func_callback_t callback) {
+  return release_func(Func::make(store, type, wasm_callback,
+                                 reinterpret_cast<void*>(callback)));
 }
 
-wasm_func_t *wasm_func_new_with_env(
-  wasm_store_t* store, const wasm_functype_t* type,
-  wasm_func_callback_with_env_t callback, void *env, void (*finalizer)(void*)
-) {
+wasm_func_t* wasm_func_new_with_env(wasm_store_t* store,
+                                    const wasm_functype_t* type,
+                                    wasm_func_callback_with_env_t callback,
+                                    void* env,
+                                    void (*finalizer)(void*)) {
   auto env2 = new wasm_callback_env_t{callback, env, finalizer};
-  return release_func(Func::make(store, type, wasm_callback_with_env, env2, wasm_callback_env_finalizer));
+  return release_func(Func::make(store, type, wasm_callback_with_env, env2,
+                                 wasm_callback_env_finalizer));
 }
 
 wasm_functype_t* wasm_func_type(const wasm_func_t* func) {
@@ -825,20 +830,20 @@ size_t wasm_func_result_arity(const wasm_func_t* func) {
   return func->result_arity();
 }
 
-wasm_trap_t* wasm_func_call(
-  const wasm_func_t* func, const wasm_val_t args[], wasm_val_t results[]
-) {
-  return release_trap(func->call(reveal_val_vec(args), reveal_val_vec(results)));
+wasm_trap_t* wasm_func_call(const wasm_func_t* func,
+                            const wasm_val_t args[],
+                            wasm_val_t results[]) {
+  return release_trap(
+      func->call(reveal_val_vec(args), reveal_val_vec(results)));
 }
-
 
 // Global Instances
 
 WASM_DEFINE_REF(global, Global)
 
-wasm_global_t* wasm_global_new(
-  wasm_store_t* store, const wasm_globaltype_t* type, const wasm_val_t* val
-) {
+wasm_global_t* wasm_global_new(wasm_store_t* store,
+                               const wasm_globaltype_t* type,
+                               const wasm_val_t* val) {
   auto val_ = borrow_val(val);
   return release_global(Global::make(store, type, val_.it));
 }
@@ -856,14 +861,13 @@ void wasm_global_set(wasm_global_t* global, const wasm_val_t* val) {
   global->set(val_.it);
 }
 
-
 // Table Instances
 
 WASM_DEFINE_REF(table, Table)
 
-wasm_table_t* wasm_table_new(
-  wasm_store_t* store, const wasm_tabletype_t* type, wasm_ref_t* ref
-) {
+wasm_table_t* wasm_table_new(wasm_store_t* store,
+                             const wasm_tabletype_t* type,
+                             wasm_ref_t* ref) {
   return release_table(Table::make(store, type, ref));
 }
 
@@ -875,9 +879,9 @@ wasm_ref_t* wasm_table_get(const wasm_table_t* table, wasm_table_size_t index) {
   return release_ref(table->get(index));
 }
 
-bool wasm_table_set(
-  wasm_table_t* table, wasm_table_size_t index, wasm_ref_t* ref
-) {
+bool wasm_table_set(wasm_table_t* table,
+                    wasm_table_size_t index,
+                    wasm_ref_t* ref) {
   return table->set(index, ref);
 }
 
@@ -885,20 +889,18 @@ wasm_table_size_t wasm_table_size(const wasm_table_t* table) {
   return table->size();
 }
 
-bool wasm_table_grow(
-  wasm_table_t* table, wasm_table_size_t delta, wasm_ref_t* ref
-) {
+bool wasm_table_grow(wasm_table_t* table,
+                     wasm_table_size_t delta,
+                     wasm_ref_t* ref) {
   return table->grow(delta, ref);
 }
-
 
 // Memory Instances
 
 WASM_DEFINE_REF(memory, Memory)
 
-wasm_memory_t* wasm_memory_new(
-  wasm_store_t* store, const wasm_memorytype_t* type
-) {
+wasm_memory_t* wasm_memory_new(wasm_store_t* store,
+                               const wasm_memorytype_t* type) {
   return release_memory(Memory::make(store, type));
 }
 
@@ -921,7 +923,6 @@ wasm_memory_pages_t wasm_memory_size(const wasm_memory_t* memory) {
 bool wasm_memory_grow(wasm_memory_t* memory, wasm_memory_pages_t delta) {
   return memory->grow(delta);
 }
-
 
 // Externals
 
@@ -977,40 +978,38 @@ wasm_memory_t* wasm_extern_as_memory(wasm_extern_t* external) {
 const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t* external) {
   return hide_func(external->func());
 }
-const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t* external) {
+const wasm_global_t* wasm_extern_as_global_const(
+    const wasm_extern_t* external) {
   return hide_global(external->global());
 }
 const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t* external) {
   return hide_table(external->table());
 }
-const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t* external) {
+const wasm_memory_t* wasm_extern_as_memory_const(
+    const wasm_extern_t* external) {
   return hide_memory(external->memory());
 }
-
 
 // Module Instances
 
 WASM_DEFINE_REF(instance, Instance)
 
-wasm_instance_t* wasm_instance_new(
-  wasm_store_t* store,
-  const wasm_module_t* module,
-  const wasm_extern_t* const imports[],
-  wasm_trap_t** trap
-) {
+wasm_instance_t* wasm_instance_new(wasm_store_t* store,
+                                   const wasm_module_t* module,
+                                   const wasm_extern_t* const imports[],
+                                   wasm_trap_t** trap) {
   own<Trap> error;
-  auto instance = release_instance(Instance::make(store, module,
-    reinterpret_cast<const Extern* const*>(imports), &error));
-  if (trap) *trap = hide_trap(error.release());
+  auto instance = release_instance(Instance::make(
+      store, module, reinterpret_cast<const Extern* const*>(imports), &error));
+  if (trap)
+    *trap = hide_trap(error.release());
   return instance;
 }
 
-void wasm_instance_exports(
-  const wasm_instance_t* instance, wasm_extern_vec_t* out
-) {
+void wasm_instance_exports(const wasm_instance_t* instance,
+                           wasm_extern_vec_t* out) {
   *out = release_extern_vec(instance->exports());
 }
-
 
 wasm_instance_t* wasm_frame_instance(const wasm_frame_t* frame) {
   return hide_instance(reveal_frame(frame)->instance());

--- a/src/wasm-v8-lowlevel.cc
+++ b/src/wasm-v8-lowlevel.cc
@@ -1,27 +1,24 @@
 #include "wasm-v8-lowlevel.hh"
 
 // TODO(v8): if we don't include these, api.h does not compile
-#include "objects/objects.h"
+#include "api/api-inl.h"
+#include "api/api.h"
 #include "objects/bigint.h"
+#include "objects/fixed-array.h"
+#include "objects/js-collection.h"
+#include "objects/js-promise.h"
 #include "objects/managed.h"
 #include "objects/module.h"
+#include "objects/objects.h"
+#include "objects/ordered-hash-table.h"
 #include "objects/shared-function-info.h"
 #include "objects/templates.h"
-#include "objects/fixed-array.h"
-#include "objects/ordered-hash-table.h"
-#include "objects/js-promise.h"
-#include "objects/js-collection.h"
-
-#include "api/api.h"
-#include "api/api-inl.h"
-#include "wasm/wasm-objects.h"
 #include "wasm/wasm-objects-inl.h"
+#include "wasm/wasm-objects.h"
 #include "wasm/wasm-serialization.h"
-
 
 namespace v8 {
 namespace wasm {
-
 
 // Objects
 
@@ -31,16 +28,17 @@ auto object_isolate(v8::Local<v8::Object> obj) -> v8::Isolate* {
 }
 
 auto object_isolate(const v8::Persistent<v8::Object>& obj) -> v8::Isolate* {
-  struct FakePersistent { v8::Object* val; };
+  struct FakePersistent {
+    v8::Object* val;
+  };
   auto v8_obj = reinterpret_cast<const FakePersistent*>(&obj)->val;
   return v8_obj->GetIsolate();
 }
 
-template<class T>
+template <class T>
 auto object_handle(T v8_obj) -> v8::internal::Handle<T> {
   return handle(v8_obj, v8_obj.GetIsolate());
 }
-
 
 auto object_is_module(v8::Local<v8::Object> obj) -> bool {
   auto v8_obj = v8::Utils::OpenHandle(*obj);
@@ -77,124 +75,157 @@ auto object_is_error(v8::Local<v8::Object> obj) -> bool {
   return v8_obj->IsJSError();
 }
 
-
-
 // Foreign pointers
 
 auto foreign_new(v8::Isolate* isolate, void* ptr) -> v8::Local<v8::Value> {
-  auto foreign = v8::FromCData(
-    reinterpret_cast<v8::internal::Isolate*>(isolate),
-    reinterpret_cast<v8::internal::Address>(ptr)
-  );
+  auto foreign =
+      v8::FromCData(reinterpret_cast<v8::internal::Isolate*>(isolate),
+                    reinterpret_cast<v8::internal::Address>(ptr));
   return v8::Utils::ToLocal(foreign);
 }
 
 auto foreign_get(v8::Local<v8::Value> val) -> void* {
   auto foreign = v8::Utils::OpenHandle(*val);
-  if (!foreign->IsForeign()) return nullptr;
+  if (!foreign->IsForeign())
+    return nullptr;
   auto addr = v8::ToCData<v8::internal::Address>(*foreign);
   return reinterpret_cast<void*>(addr);
 }
 
-
 struct ManagedData {
-  ManagedData(void* info, void (*finalizer)(void*)) :
-    info(info), finalizer(finalizer) {}
+  ManagedData(void* info, void (*finalizer)(void*))
+      : info(info), finalizer(finalizer) {}
 
   ~ManagedData() {
-    if (finalizer) (*finalizer)(info);
+    if (finalizer)
+      (*finalizer)(info);
   }
 
   void* info;
   void (*finalizer)(void*);
 };
 
-auto managed_new(v8::Isolate* isolate, void* ptr, void (*finalizer)(void*)) -> v8::Local<v8::Value> {
+auto managed_new(v8::Isolate* isolate, void* ptr, void (*finalizer)(void*))
+    -> v8::Local<v8::Value> {
   assert(ptr);
   auto managed = v8::internal::Managed<ManagedData>::FromUniquePtr(
-    reinterpret_cast<v8::internal::Isolate*>(isolate), sizeof(ManagedData),
-    std::unique_ptr<ManagedData>(new ManagedData(ptr, finalizer))
-  );
+      reinterpret_cast<v8::internal::Isolate*>(isolate), sizeof(ManagedData),
+      std::unique_ptr<ManagedData>(new ManagedData(ptr, finalizer)));
   return v8::Utils::ToLocal(managed);
 }
 
 auto managed_get(v8::Local<v8::Value> val) -> void* {
   auto v8_val = v8::Utils::OpenHandle(*val);
-  if (!v8_val->IsForeign()) return nullptr;
+  if (!v8_val->IsForeign())
+    return nullptr;
   auto managed =
-    v8::internal::Handle<v8::internal::Managed<ManagedData>>::cast(v8_val);
+      v8::internal::Handle<v8::internal::Managed<ManagedData>>::cast(v8_val);
   return managed->raw()->info;
 }
 
-
 // Types
 
-auto v8_valtype_to_wasm(v8::internal::wasm::ValueType v8_valtype) -> val_kind_t {
+auto v8_valtype_to_wasm(v8::internal::wasm::ValueType v8_valtype)
+    -> val_kind_t {
   switch (v8_valtype) {
-    case v8::internal::wasm::kWasmI32: return I32;
-    case v8::internal::wasm::kWasmI64: return I64;
-    case v8::internal::wasm::kWasmF32: return F32;
-    case v8::internal::wasm::kWasmF64: return F64;
-    case v8::internal::wasm::kWasmAnyRef: return ANYREF;
-    case v8::internal::wasm::kWasmAnyFunc: return FUNCREF;
+    case v8::internal::wasm::kWasmI32:
+      return I32;
+    case v8::internal::wasm::kWasmI64:
+      return I64;
+    case v8::internal::wasm::kWasmF32:
+      return F32;
+    case v8::internal::wasm::kWasmF64:
+      return F64;
+    case v8::internal::wasm::kWasmAnyRef:
+      return ANYREF;
+    case v8::internal::wasm::kWasmAnyFunc:
+      return FUNCREF;
     default:
       UNREACHABLE();
   }
 }
 
 auto func_type_param_arity(v8::Local<v8::Object> function) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
-  auto v8_function = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
+  auto v8_function =
+      v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
   v8::internal::wasm::FunctionSig* sig =
-    v8_function->instance().module()->functions[v8_function->function_index()].sig;
+      v8_function->instance()
+          .module()
+          ->functions[v8_function->function_index()]
+          .sig;
   return static_cast<uint32_t>(sig->parameter_count());
 }
 
 auto func_type_result_arity(v8::Local<v8::Object> function) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
-  auto v8_function = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
+  auto v8_function =
+      v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
   v8::internal::wasm::FunctionSig* sig =
-    v8_function->instance().module()->functions[v8_function->function_index()].sig;
+      v8_function->instance()
+          .module()
+          ->functions[v8_function->function_index()]
+          .sig;
   return static_cast<uint32_t>(sig->return_count());
 }
 
 auto func_type_param(v8::Local<v8::Object> function, size_t i) -> val_kind_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
-  auto v8_function = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
+  auto v8_function =
+      v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
   v8::internal::wasm::FunctionSig* sig =
-    v8_function->instance().module()->functions[v8_function->function_index()].sig;
+      v8_function->instance()
+          .module()
+          ->functions[v8_function->function_index()]
+          .sig;
   return v8_valtype_to_wasm(sig->GetParam(i));
 }
 
 auto func_type_result(v8::Local<v8::Object> function, size_t i) -> val_kind_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
-  auto v8_function = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(function);
+  auto v8_function =
+      v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_object);
   v8::internal::wasm::FunctionSig* sig =
-    v8_function->instance().module()->functions[v8_function->function_index()].sig;
+      v8_function->instance()
+          .module()
+          ->functions[v8_function->function_index()]
+          .sig;
   return v8_valtype_to_wasm(sig->GetReturn(i));
 }
 
 auto global_type_content(v8::Local<v8::Object> global) -> val_kind_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_valtype_to_wasm(v8_global->type());
 }
 
 auto global_type_mutable(v8::Local<v8::Object> global) -> bool {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_global->is_mutable();
 }
 
 auto table_type_min(v8::Local<v8::Object> table) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
   return v8_table->current_length();
 }
 
 auto table_type_max(v8::Local<v8::Object> table) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
   auto v8_max_obj = v8_table->maximum_length();
   uint32_t max;
   return v8_max_obj.ToUint32(&max) ? max : 0xffffffffu;
@@ -205,237 +236,304 @@ auto memory_type_min(v8::Local<v8::Object> memory) -> uint32_t {
 }
 
 auto memory_type_max(v8::Local<v8::Object> memory) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
-  auto v8_memory = v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
-  return v8_memory->has_maximum_pages() ? v8_memory->maximum_pages() : 0xffffffffu;
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
+  auto v8_memory =
+      v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
+  return v8_memory->has_maximum_pages() ? v8_memory->maximum_pages()
+                                        : 0xffffffffu;
 }
-
 
 // Modules
 
 auto module_binary_size(v8::Local<v8::Object> module) -> size_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
-  auto v8_module = v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
+  auto v8_module =
+      v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
   return v8_module->native_module()->wire_bytes().size();
 }
 
 auto module_binary(v8::Local<v8::Object> module) -> const char* {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
-  auto v8_module = v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
-  return reinterpret_cast<const char*>(v8_module->native_module()->wire_bytes().begin());
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
+  auto v8_module =
+      v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
+  return reinterpret_cast<const char*>(
+      v8_module->native_module()->wire_bytes().begin());
 }
 
 auto module_serialize_size(v8::Local<v8::Object> module) -> size_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
-  auto v8_module = v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
+  auto v8_module =
+      v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
   v8::internal::wasm::WasmSerializer serializer(v8_module->native_module());
   return serializer.GetSerializedNativeModuleSize();
 }
 
-auto module_serialize(v8::Local<v8::Object> module, char* buffer, size_t size) -> bool {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
-  auto v8_module = v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
+auto module_serialize(v8::Local<v8::Object> module, char* buffer, size_t size)
+    -> bool {
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(module);
+  auto v8_module =
+      v8::internal::Handle<v8::internal::WasmModuleObject>::cast(v8_object);
   v8::internal::wasm::WasmSerializer serializer(v8_module->native_module());
-  return serializer.SerializeNativeModule({reinterpret_cast<uint8_t*>(buffer), size});
+  return serializer.SerializeNativeModule(
+      {reinterpret_cast<uint8_t*>(buffer), size});
 }
 
-auto module_deserialize(
-  v8::Isolate* isolate,
-  const char* binary, size_t binary_size,
-  const char* buffer, size_t buffer_size
-) -> v8::MaybeLocal<v8::Object> {
+auto module_deserialize(v8::Isolate* isolate,
+                        const char* binary,
+                        size_t binary_size,
+                        const char* buffer,
+                        size_t buffer_size) -> v8::MaybeLocal<v8::Object> {
   auto v8_isolate = reinterpret_cast<v8::internal::Isolate*>(isolate);
-  auto maybe_v8_module =
-    v8::internal::wasm::DeserializeNativeModule(v8_isolate,
-      {reinterpret_cast<const uint8_t*>(buffer), buffer_size},
+  auto maybe_v8_module = v8::internal::wasm::DeserializeNativeModule(
+      v8_isolate, {reinterpret_cast<const uint8_t*>(buffer), buffer_size},
       {reinterpret_cast<const uint8_t*>(binary), binary_size});
-  if (maybe_v8_module.is_null()) return v8::MaybeLocal<v8::Object>();
-  auto v8_module = v8::internal::Handle<v8::internal::JSObject>::cast(maybe_v8_module.ToHandleChecked());
+  if (maybe_v8_module.is_null())
+    return v8::MaybeLocal<v8::Object>();
+  auto v8_module = v8::internal::Handle<v8::internal::JSObject>::cast(
+      maybe_v8_module.ToHandleChecked());
   return v8::MaybeLocal<v8::Object>(v8::Utils::ToLocal(v8_module));
 }
-
 
 // Instances
 
 auto instance_module(v8::Local<v8::Object> instance) -> v8::Local<v8::Object> {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(instance);
-  auto v8_instance = v8::internal::Handle<v8::internal::WasmInstanceObject>::cast(v8_object);
-  auto v8_module = object_handle(v8::internal::JSObject::cast(v8_instance->module_object()));
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(instance);
+  auto v8_instance =
+      v8::internal::Handle<v8::internal::WasmInstanceObject>::cast(v8_object);
+  auto v8_module =
+      object_handle(v8::internal::JSObject::cast(v8_instance->module_object()));
   return v8::Utils::ToLocal(v8_module);
 }
 
 auto instance_exports(v8::Local<v8::Object> instance) -> v8::Local<v8::Object> {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(instance);
-  auto v8_instance = v8::internal::Handle<v8::internal::WasmInstanceObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(instance);
+  auto v8_instance =
+      v8::internal::Handle<v8::internal::WasmInstanceObject>::cast(v8_object);
   auto v8_exports = object_handle(v8_instance->exports_object());
   return v8::Utils::ToLocal(v8_exports);
 }
 
-
 // Externals
 
 auto extern_kind(v8::Local<v8::Object> external) -> extern_kind_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(external);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(external);
 
-  if (v8::internal::WasmExportedFunction::IsWasmExportedFunction(*v8_object)) return EXTERN_FUNC;
-  if (v8_object->IsWasmGlobalObject()) return EXTERN_GLOBAL;
-  if (v8_object->IsWasmTableObject()) return EXTERN_TABLE;
-  if (v8_object->IsWasmMemoryObject()) return EXTERN_MEMORY;
+  if (v8::internal::WasmExportedFunction::IsWasmExportedFunction(*v8_object))
+    return EXTERN_FUNC;
+  if (v8_object->IsWasmGlobalObject())
+    return EXTERN_GLOBAL;
+  if (v8_object->IsWasmTableObject())
+    return EXTERN_TABLE;
+  if (v8_object->IsWasmMemoryObject())
+    return EXTERN_MEMORY;
   UNREACHABLE();
 }
-
 
 // Functions
 
 auto func_instance(v8::Local<v8::Function> function) -> v8::Local<v8::Object> {
   auto v8_function = v8::Utils::OpenHandle(*function);
-  auto v8_func = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(v8_function);
-  auto v8_instance = object_handle(v8::internal::JSObject::cast(v8_func->instance()));
+  auto v8_func = v8::internal::Handle<v8::internal::WasmExportedFunction>::cast(
+      v8_function);
+  auto v8_instance =
+      object_handle(v8::internal::JSObject::cast(v8_func->instance()));
   return v8::Utils::ToLocal(v8_instance);
 }
-
 
 // Globals
 
 auto global_get_i32(v8::Local<v8::Object> global) -> int32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_global->GetI32();
 }
 auto global_get_i64(v8::Local<v8::Object> global) -> int64_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_global->GetI64();
 }
 auto global_get_f32(v8::Local<v8::Object> global) -> float {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_global->GetF32();
 }
 auto global_get_f64(v8::Local<v8::Object> global) -> double {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8_global->GetF64();
 }
 auto global_get_ref(v8::Local<v8::Object> global) -> v8::Local<v8::Value> {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   return v8::Utils::ToLocal(v8_global->GetRef());
 }
 
 void global_set_i32(v8::Local<v8::Object> global, int32_t val) {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   v8_global->SetI32(val);
 }
 void global_set_i64(v8::Local<v8::Object> global, int64_t val) {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   v8_global->SetI64(val);
 }
 void global_set_f32(v8::Local<v8::Object> global, float val) {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   v8_global->SetF32(val);
 }
 void global_set_f64(v8::Local<v8::Object> global, double val) {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
   v8_global->SetF64(val);
 }
 void global_set_ref(v8::Local<v8::Object> global, v8::Local<v8::Value> val) {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
-  auto v8_global = v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
-  v8_global->SetAnyRef(v8::Utils::OpenHandle<v8::Value, v8::internal::Object>(val));
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(global);
+  auto v8_global =
+      v8::internal::Handle<v8::internal::WasmGlobalObject>::cast(v8_object);
+  v8_global->SetAnyRef(
+      v8::Utils::OpenHandle<v8::Value, v8::internal::Object>(val));
 }
-
 
 // Tables
 
-auto table_get(v8::Local<v8::Object> table, size_t index) -> v8::MaybeLocal<v8::Value> {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+auto table_get(v8::Local<v8::Object> table, size_t index)
+    -> v8::MaybeLocal<v8::Value> {
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
   // TODO(v8): This should happen in WasmTableObject::Get.
-  if (index > v8_table->current_length()) return v8::MaybeLocal<v8::Value>();
+  if (index > v8_table->current_length())
+    return v8::MaybeLocal<v8::Value>();
 
   v8::internal::Handle<v8::internal::Object> v8_value =
-    v8::internal::WasmTableObject::Get(
-      v8_table->GetIsolate(), v8_table, static_cast<uint32_t>(index));
-  return v8::Utils::ToLocal(v8::internal::Handle<v8::internal::Object>::cast(v8_value));
+      v8::internal::WasmTableObject::Get(v8_table->GetIsolate(), v8_table,
+                                         static_cast<uint32_t>(index));
+  return v8::Utils::ToLocal(
+      v8::internal::Handle<v8::internal::Object>::cast(v8_value));
 }
 
-auto table_set(
-  v8::Local<v8::Object> table, size_t index, v8::Local<v8::Value> value
-) -> bool {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+auto table_set(v8::Local<v8::Object> table,
+               size_t index,
+               v8::Local<v8::Value> value) -> bool {
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
   auto v8_value = v8::Utils::OpenHandle<v8::Value, v8::internal::Object>(value);
   // TODO(v8): This should happen in WasmTableObject::Set.
-  if (index >= v8_table->current_length()) return false;
+  if (index >= v8_table->current_length())
+    return false;
 
-  { v8::TryCatch handler(table->GetIsolate());
+  {
+    v8::TryCatch handler(table->GetIsolate());
     v8::internal::WasmTableObject::Set(v8_table->GetIsolate(), v8_table,
-      static_cast<uint32_t>(index), v8_value);
-    if (handler.HasCaught()) return false;
+                                       static_cast<uint32_t>(index), v8_value);
+    if (handler.HasCaught())
+      return false;
   }
 
   return true;
 }
 
 auto table_size(v8::Local<v8::Object> table) -> size_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
   return v8_table->current_length();
 }
 
-auto table_grow(
-  v8::Local<v8::Object> table, size_t delta, v8::Local<v8::Value> init
-) -> bool {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
-  auto v8_table = v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
-  if (delta > 0xfffffffflu) return false;
+auto table_grow(v8::Local<v8::Object> table,
+                size_t delta,
+                v8::Local<v8::Value> init) -> bool {
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(table);
+  auto v8_table =
+      v8::internal::Handle<v8::internal::WasmTableObject>::cast(v8_object);
+  if (delta > 0xfffffffflu)
+    return false;
   auto old_size = v8_table->current_length();
   auto new_size = old_size + static_cast<uint32_t>(delta);
   // TODO(v8): This should happen in WasmTableObject::Grow.
-  if (new_size > table_type_max(table)) return false;
+  if (new_size > table_type_max(table))
+    return false;
 
-  { v8::TryCatch handler(table->GetIsolate());
+  {
+    v8::TryCatch handler(table->GetIsolate());
     v8::internal::WasmTableObject::Grow(
-      v8_table->GetIsolate(), v8_table, static_cast<uint32_t>(delta),
-      v8::Utils::OpenHandle<v8::Value, v8::internal::Object>(init));
-    if (handler.HasCaught()) return false;
+        v8_table->GetIsolate(), v8_table, static_cast<uint32_t>(delta),
+        v8::Utils::OpenHandle<v8::Value, v8::internal::Object>(init));
+    if (handler.HasCaught())
+      return false;
   }
 
   return true;
 }
 
-
 // Memory
 
 auto memory_data(v8::Local<v8::Object> memory) -> char* {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
-  auto v8_memory = v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
+  auto v8_memory =
+      v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
   return reinterpret_cast<char*>(v8_memory->array_buffer().backing_store());
 }
 
-auto memory_data_size(v8::Local<v8::Object> memory)-> size_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
-  auto v8_memory = v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
+auto memory_data_size(v8::Local<v8::Object> memory) -> size_t {
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
+  auto v8_memory =
+      v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
   return v8_memory->array_buffer().byte_length();
 }
 
 auto memory_size(v8::Local<v8::Object> memory) -> uint32_t {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
-  auto v8_memory = v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
-  return static_cast<uint32_t>(
-    v8_memory->array_buffer().byte_length() / v8::internal::wasm::kWasmPageSize);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
+  auto v8_memory =
+      v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
+  return static_cast<uint32_t>(v8_memory->array_buffer().byte_length() /
+                               v8::internal::wasm::kWasmPageSize);
 }
 
 auto memory_grow(v8::Local<v8::Object> memory, uint32_t delta) -> bool {
-  auto v8_object = v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
-  auto v8_memory = v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
-  auto old = v8::internal::WasmMemoryObject::Grow(
-    v8_memory->GetIsolate(), v8_memory, delta);
+  auto v8_object =
+      v8::Utils::OpenHandle<v8::Object, v8::internal::JSReceiver>(memory);
+  auto v8_memory =
+      v8::internal::Handle<v8::internal::WasmMemoryObject>::cast(v8_object);
+  auto old = v8::internal::WasmMemoryObject::Grow(v8_memory->GetIsolate(),
+                                                  v8_memory, delta);
   return old != -1;
 }
 

--- a/src/wasm-v8-lowlevel.hh
+++ b/src/wasm-v8-lowlevel.hh
@@ -42,7 +42,8 @@ auto module_binary_size(v8::Local<v8::Object> module) -> size_t;
 auto module_binary(v8::Local<v8::Object> module) -> const char*;
 auto module_serialize_size(v8::Local<v8::Object> module) -> size_t;
 auto module_serialize(v8::Local<v8::Object> module, char*, size_t) -> bool;
-auto module_deserialize(v8::Isolate*, const char*, size_t, const char*, size_t) -> v8::MaybeLocal<v8::Object>;
+auto module_deserialize(v8::Isolate*, const char*, size_t, const char*, size_t)
+    -> v8::MaybeLocal<v8::Object>;
 
 auto instance_module(v8::Local<v8::Object> instance) -> v8::Local<v8::Object>;
 auto instance_exports(v8::Local<v8::Object> instance) -> v8::Local<v8::Object>;
@@ -63,13 +64,16 @@ void global_set_f32(v8::Local<v8::Object> global, float);
 void global_set_f64(v8::Local<v8::Object> global, double);
 void global_set_ref(v8::Local<v8::Object> global, v8::Local<v8::Value>);
 
-auto table_get(v8::Local<v8::Object> table, size_t index) -> v8::MaybeLocal<v8::Value>;
-auto table_set(v8::Local<v8::Object> table, size_t index, v8::Local<v8::Value>) -> bool;
+auto table_get(v8::Local<v8::Object> table, size_t index)
+    -> v8::MaybeLocal<v8::Value>;
+auto table_set(v8::Local<v8::Object> table, size_t index, v8::Local<v8::Value>)
+    -> bool;
 auto table_size(v8::Local<v8::Object> table) -> size_t;
-auto table_grow(v8::Local<v8::Object> table, size_t delta, v8::Local<v8::Value>) -> bool;
+auto table_grow(v8::Local<v8::Object> table, size_t delta, v8::Local<v8::Value>)
+    -> bool;
 
 auto memory_data(v8::Local<v8::Object> memory) -> char*;
-auto memory_data_size(v8::Local<v8::Object> memory)-> size_t;
+auto memory_data_size(v8::Local<v8::Object> memory) -> size_t;
 auto memory_size(v8::Local<v8::Object> memory) -> uint32_t;
 auto memory_grow(v8::Local<v8::Object> memory, uint32_t delta) -> bool;
 


### PR DESCRIPTION
As requested [here](https://github.com/WebAssembly/wasm-c-api/issues/80#issuecomment-548530127), this adds a .clang-format that only contains `BasedOnStyle: Chromium`, and applies it to *.c, *.cc, *.h, and *.hh, so folks can see what the impact is.