### PR TITLE
Make `wasm_global_set` a safe API.

### DIFF
--- a/example/hostref.c
+++ b/example/hostref.c
@@ -227,7 +227,8 @@ int main(int argc, const char* argv[]) {
   assert(val.kind == WASM_ANYREF);
   check(val.of.ref, NULL);
   val.of.ref = host2;
-  wasm_global_set(global, &val);
+  own wasm_trap_t *global_set_trap = wasm_global_set(global, &val);
+  assert(global_set_trap == NULL);
   check(call_v_r(global_get), host2);
   wasm_global_get(global, &val);
   assert(val.kind == WASM_ANYREF);

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -436,7 +436,14 @@ WASM_API_EXTERN own wasm_global_t* wasm_global_new(
 WASM_API_EXTERN own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
 WASM_API_EXTERN void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
-WASM_API_EXTERN void wasm_global_set(wasm_global_t*, const wasm_val_t*);
+
+/// Perform a `global.set` operation. If the global is immutable or if the new
+/// value has the wrong type, return an error.
+WASM_API_EXTERN own wasm_trap_t* wasm_global_set(wasm_global_t*, const wasm_val_t*);
+
+/// Similar to `wasm_global_set`, except with undefined behavior if the global
+/// is immutable or if the new value has the wrong type.
+WASM_API_EXTERN void wasm_global_set_unsafe(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances


### PR DESCRIPTION
Make `wasm_global_set` a safe API by allowing it to return a trap
in error cases.

Traps in the wasm spec are used to report runtime errors, and the
errors `wasm_global_set` reports are things that wasm would catch
at validation time.

Nevertheless, using a trap here is consistent with the official
JS API raising exceptions on the same conditions. And, it provides
a message explaining the reason for the error.

To support users for whom mutablility and type checks are believed
to be unacceptable overhead, add a `wasm_global_set_unsafe` function
which skips those checks, at the penalty of undefined behavior.