### PR TITLE
Add safety checks to several C API functions.

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // Print a Wasm value
 void wasm_val_print(wasm_val_t val) {
   switch (val.kind) {
@@ -112,7 +114,7 @@ int main(int argc, const char* argv[]) {
     wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
   };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, imports, array_len(imports), NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -146,7 +148,7 @@ int main(int argc, const char* argv[]) {
   args[1].kind = WASM_I32;
   args[1].of.i32 = 4;
   wasm_val_t results[1];
-  if (wasm_func_call(run_func, args, results)) {
+  if (wasm_func_call(store, run_func, args, array_len(args), results, array_len(results))) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/callback.c
+++ b/example/callback.c
@@ -110,11 +110,16 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
+  wasm_extern_t* imports[] = {
     wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
   };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -148,7 +153,13 @@ int main(int argc, const char* argv[]) {
   args[1].kind = WASM_I32;
   args[1].of.i32 = 4;
   wasm_val_t results[1];
-  if (wasm_func_call(store, run_func, args, array_len(args), results, array_len(results))) {
+  if (wasm_func_call(
+        store,
+        run_func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { array_len(results), results }
+      )
+  ) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -51,7 +51,7 @@ void run_in_store(wasm_store_t* store) {
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) printf("%d\n", i);
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, NULL, 0, NULL);
+      wasm_instance_new(store, module, (wasm_extern_vec_t) { 0, NULL }, NULL);
     if (!instance) {
       printf("> Error instantiating module %d!\n", i);
       exit(1);

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -51,7 +51,7 @@ void run_in_store(wasm_store_t* store) {
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) printf("%d\n", i);
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, NULL, NULL);
+      wasm_instance_new(store, module, NULL, 0, NULL);
     if (!instance) {
       printf("> Error instantiating module %d!\n", i);
       exit(1);

--- a/example/global.c
+++ b/example/global.c
@@ -52,7 +52,12 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
   { \
     wasm_val_t results[1]; \
     wasm_trap_t* trap = \
-      wasm_func_call(store, func, NULL, 0, results, array_len(results)); \
+      wasm_func_call( \
+        store, \
+        func, \
+        (wasm_val_vec_t) { 0, NULL }, \
+        (wasm_val_vec_t) { array_len(results), results } \
+      ); \
     if (trap) { \
       printf("> Error on result\n"); \
       exit(1); \
@@ -127,14 +132,19 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
+  wasm_extern_t* imports[] = {
     wasm_global_as_extern(const_f32_import),
     wasm_global_as_extern(const_i64_import),
     wasm_global_as_extern(var_f32_import),
     wasm_global_as_extern(var_i64_import)
   };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -213,13 +223,21 @@ int main(int argc, const char* argv[]) {
 
   // Modify variables through calls and check again.
   wasm_val_t args73[] = { {.kind = WASM_F32, .of = {.f32 = 73}} };
-  wasm_func_call(store, set_var_f32_import, args73, array_len(args73), NULL, 0);
+  wasm_func_call(store, set_var_f32_import,
+                 (wasm_val_vec_t) { array_len(args73), args73 },
+                 (wasm_val_vec_t) { 0, NULL });
   wasm_val_t args74[] = { {.kind = WASM_I64, .of = {.i64 = 74}} };
-  wasm_func_call(store, set_var_i64_import, args74, array_len(args74), NULL, 0);
+  wasm_func_call(store, set_var_i64_import,
+                 (wasm_val_vec_t) { array_len(args74), args74 },
+                 (wasm_val_vec_t) { 0, NULL });
   wasm_val_t args77[] = { {.kind = WASM_F32, .of = {.f32 = 77}} };
-  wasm_func_call(store, set_var_f32_export, args77, array_len(args77), NULL, 0);
+  wasm_func_call(store, set_var_f32_export,
+                 (wasm_val_vec_t) { array_len(args77), args77 },
+                 (wasm_val_vec_t) { 0, NULL });
   wasm_val_t args78[] = { {.kind = WASM_I64, .of = {.i64 = 78}} };
-  wasm_func_call(store, set_var_i64_export, args78, array_len(args78), NULL, 0);
+  wasm_func_call(store, set_var_i64_export,
+                 (wasm_val_vec_t) { array_len(args78), args78 },
+                 (wasm_val_vec_t) { 0, NULL });
 
   check_global(var_f32_import, f32, 73);
   check_global(var_i64_import, i64, 74);

--- a/example/hello.c
+++ b/example/hello.c
@@ -63,9 +63,14 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -92,7 +97,13 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(store, run_func, NULL, 0, NULL, 0)) {
+  if (wasm_func_call(
+        store,
+        run_func,
+        (wasm_val_vec_t) { 0, NULL },
+        (wasm_val_vec_t) { 0, NULL }
+      )
+  ) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/hello.c
+++ b/example/hello.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(
   const wasm_val_t args[], wasm_val_t results[]
@@ -63,7 +65,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, imports, array_len(imports), NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -90,7 +92,7 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(run_func, NULL, NULL)) {
+  if (wasm_func_call(store, run_func, NULL, 0, NULL, 0)) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/hostref.c
+++ b/example/hostref.c
@@ -50,7 +50,13 @@ wasm_table_t* get_export_table(const wasm_extern_vec_t* exports, size_t i) {
 own wasm_ref_t* call_v_r(wasm_store_t* store, const wasm_func_t* func) {
   printf("call_v_r... "); fflush(stdout);
   wasm_val_t results[1];
-  if (wasm_func_call(store, func, NULL, 0, results, array_len(results))) {
+  if (wasm_func_call(
+        store,
+        func,
+        (wasm_val_vec_t) { 0, NULL },
+        (wasm_val_vec_t) { array_len(results), results }
+      )
+  ) {
     printf("> Error calling function!\n");
     exit(1);
   }
@@ -63,7 +69,13 @@ void call_r_v(wasm_store_t* store, const wasm_func_t* func, wasm_ref_t* ref) {
   wasm_val_t args[1];
   args[0].kind = WASM_ANYREF;
   args[0].of.ref = ref;
-  if (wasm_func_call(store, func, args, array_len(args), NULL, 0)) {
+  if (wasm_func_call(
+        store,
+        func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { 0, NULL }
+      )
+  ) {
     printf("> Error calling function!\n");
     exit(1);
   }
@@ -76,7 +88,13 @@ own wasm_ref_t* call_r_r(wasm_store_t* store, const wasm_func_t* func, wasm_ref_
   args[0].kind = WASM_ANYREF;
   args[0].of.ref = ref;
   wasm_val_t results[1];
-  if (wasm_func_call(store, func, args, array_len(args), results, array_len(results))) {
+  if (wasm_func_call(
+        store,
+        func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { array_len(results), results }
+      )
+  ) {
     printf("> Error calling function!\n");
     exit(1);
   }
@@ -91,7 +109,13 @@ void call_ir_v(wasm_store_t* store, const wasm_func_t* func, int32_t i, wasm_ref
   args[0].of.i32 = i;
   args[1].kind = WASM_ANYREF;
   args[1].of.ref = ref;
-  if (wasm_func_call(store, func, args, array_len(args), NULL, 0)) {
+  if (wasm_func_call(
+        store,
+        func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { 0, NULL }
+      )
+  ) {
     printf("> Error calling function!\n");
     exit(1);
   }
@@ -104,7 +128,13 @@ own wasm_ref_t* call_i_r(wasm_store_t* store, const wasm_func_t* func, int32_t i
   args[0].kind = WASM_I32;
   args[0].of.i32 = i;
   wasm_val_t results[1];
-  if (wasm_func_call(store, func, args, array_len(args), results, array_len(results))) {
+  if (wasm_func_call(
+        store,
+        func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { array_len(results), results }
+      )
+  ) {
     printf("> Error calling function!\n");
     exit(1);
   }
@@ -169,9 +199,14 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(callback_func) };
+  wasm_extern_t* imports[] = { wasm_func_as_extern(callback_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/multi.c
+++ b/example/multi.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
   const wasm_val_t args[], wasm_val_t results[]
@@ -91,7 +93,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   const wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, imports, array_len(imports), NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -128,7 +130,7 @@ int main(int argc, const char* argv[]) {
   args[3].kind = WASM_I32;
   args[3].of.i32 = 4;
   wasm_val_t results[4];
-  if (wasm_func_call(run_func, args, results)) {
+  if (wasm_func_call(store, run_func, args, array_len(args), results, array_len(results))) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/multi.c
+++ b/example/multi.c
@@ -91,9 +91,14 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
+  wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -130,7 +135,13 @@ int main(int argc, const char* argv[]) {
   args[3].kind = WASM_I32;
   args[3].of.i32 = 4;
   wasm_val_t results[4];
-  if (wasm_func_call(store, run_func, args, array_len(args), results, array_len(results))) {
+  if (wasm_func_call(
+        store,
+        run_func,
+        (wasm_val_vec_t) { array_len(args), args },
+        (wasm_val_vec_t) { array_len(results), results }
+      )
+  ) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -118,7 +118,7 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, NULL);
+  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, 0, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -118,7 +118,12 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, 0, NULL);
+  own wasm_instance_t* instance = wasm_instance_new(
+                                    store,
+                                    module,
+                                    (wasm_extern_vec_t) { 0, NULL },
+                                    NULL
+                                  );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -78,9 +78,14 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating deserialized module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, deserialized, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      deserialized,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -107,7 +112,13 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(store, run_func, NULL, 0, NULL, 0)) {
+  if (wasm_func_call(
+        store,
+        run_func,
+        (wasm_val_vec_t) { 0, NULL },
+        (wasm_val_vec_t) { 0, NULL }
+      )
+  ) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
   printf("Calling back...\n");
@@ -78,7 +80,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating deserialized module...\n");
   const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, deserialized, imports, NULL);
+    wasm_instance_new(store, deserialized, imports, array_len(imports), NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -105,7 +107,7 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(run_func, NULL, NULL)) {
+  if (wasm_func_call(store, run_func, NULL, 0, NULL, 0)) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/start.c
+++ b/example/start.c
@@ -56,7 +56,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   own wasm_trap_t* trap = NULL;
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, NULL, &trap);
+    wasm_instance_new(store, module, NULL, 0, &trap);
   if (instance || !trap) {
     printf("> Error instantiating module, expected trap!\n");
     return 1;

--- a/example/start.c
+++ b/example/start.c
@@ -56,7 +56,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   own wasm_trap_t* trap = NULL;
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, NULL, 0, &trap);
+    wasm_instance_new(store, module, (wasm_extern_vec_t) { 0, NULL }, &trap);
   if (instance || !trap) {
     printf("> Error instantiating module, expected trap!\n");
     return 1;

--- a/example/table.c
+++ b/example/table.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // A function to be called from Wasm code.
 own wasm_trap_t* neg_callback(
   const wasm_val_t args[], wasm_val_t results[]
@@ -42,30 +44,34 @@ void check(bool success) {
   }
 }
 
-void check_table(wasm_table_t* table, int32_t i, bool expect_set) {
-  own wasm_ref_t* ref = wasm_table_get(table, i);
+void check_table(wasm_store_t* store, wasm_table_t* table, int32_t i, bool expect_set) {
+  wasm_trap_t* trap;
+  own wasm_ref_t* ref = wasm_table_get_funcref(store, table, i, &trap);
   check((ref != NULL) == expect_set);
   if (ref) wasm_ref_delete(ref);
 }
 
-void check_call(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
+void check_call(wasm_store_t* store, wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
   wasm_val_t args[2] = {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
   wasm_val_t results[1];
-  if (wasm_func_call(func, args, results) || results[0].of.i32 != expected) {
+  own wasm_trap_t *trap = wasm_func_call(store, func, args, array_len(args), results, array_len(results));
+  if (trap ||
+      results[0].of.i32 != expected)
+  {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
-void check_trap(wasm_func_t* func, int32_t arg1, int32_t arg2) {
+void check_trap(wasm_store_t* store, wasm_func_t* func, int32_t arg1, int32_t arg2) {
   wasm_val_t args[2] = {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  own wasm_trap_t* trap = wasm_func_call(func, args, NULL);
+  own wasm_trap_t* trap = wasm_func_call(store, func, args, array_len(args), NULL, 0);
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);
@@ -110,7 +116,7 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, NULL);
+  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, 0, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -143,46 +149,57 @@ int main(int argc, const char* argv[]) {
   // Check initial table.
   printf("Checking table...\n");
   check(wasm_table_size(table) == 2);
-  check_table(table, 0, false);
-  check_table(table, 1, true);
-  check_trap(call_indirect, 0, 0);
-  check_call(call_indirect, 7, 1, 7);
-  check_trap(call_indirect, 0, 2);
+  check_table(store, table, 0, false);
+  check_table(store, table, 1, true);
+  check_trap(store, call_indirect, 0, 0);
+  check_call(store, call_indirect, 7, 1, 7);
+  check_trap(store, call_indirect, 0, 2);
 
   // Mutate table.
   printf("Mutating table...\n");
-  check(wasm_table_set(table, 0, wasm_func_as_ref(g)));
-  check(wasm_table_set(table, 1, NULL));
-  check(! wasm_table_set(table, 2, wasm_func_as_ref(f)));
-  check_table(table, 0, true);
-  check_table(table, 1, false);
-  check_call(call_indirect, 7, 0, 666);
-  check_trap(call_indirect, 0, 1);
-  check_trap(call_indirect, 0, 2);
+  check(! wasm_table_set_funcref(store, table, 0, wasm_func_as_ref(g)));
+  check(! wasm_table_set_funcref(store, table, 1, NULL));
+  wasm_trap_t* trap = wasm_table_set_funcref(store, table, 2, wasm_func_as_ref(f));
+  if (!trap) {
+    printf("> Error: out of bounds table set didn't trap\n");
+    exit(1);
+  }
+  wasm_trap_delete(trap);
+  check_table(store, table, 0, true);
+  check_table(store, table, 1, false);
+  check_call(store, call_indirect, 7, 0, 666);
+  check_trap(store, call_indirect, 0, 1);
+  check_trap(store, call_indirect, 0, 2);
 
   // Grow table.
   printf("Growing table...\n");
-  check(wasm_table_grow(table, 3, NULL));
+  bool success;
+  check(! wasm_table_grow_funcref(store, table, 3, NULL, &success) && success);
   check(wasm_table_size(table) == 5);
-  check(wasm_table_set(table, 2, wasm_func_as_ref(f)));
-  check(wasm_table_set(table, 3, wasm_func_as_ref(h)));
-  check(! wasm_table_set(table, 5, NULL));
-  check_table(table, 2, true);
-  check_table(table, 3, true);
-  check_table(table, 4, false);
-  check_call(call_indirect, 5, 2, 5);
-  check_call(call_indirect, 6, 3, -6);
-  check_trap(call_indirect, 0, 4);
-  check_trap(call_indirect, 0, 5);
+  check(! wasm_table_set_funcref(store, table, 2, wasm_func_as_ref(f)));
+  check(! wasm_table_set_funcref(store, table, 3, wasm_func_as_ref(h)));
+  trap = wasm_table_set_funcref(store, table, 5, NULL);
+  if (!trap) {
+    printf("> Error: out of bounds table set didn't trap\n");
+    exit(1);
+  }
+  wasm_trap_delete(trap);
+  check_table(store, table, 2, true);
+  check_table(store, table, 3, true);
+  check_table(store, table, 4, false);
+  check_call(store, call_indirect, 5, 2, 5);
+  check_call(store, call_indirect, 6, 3, -6);
+  check_trap(store, call_indirect, 0, 4);
+  check_trap(store, call_indirect, 0, 5);
 
-  check(wasm_table_grow(table, 2, wasm_func_as_ref(f)));
+  check(! wasm_table_grow_funcref(store, table, 2, wasm_func_as_ref(f), &success) && success);
   check(wasm_table_size(table) == 7);
-  check_table(table, 5, true);
-  check_table(table, 6, true);
+  check_table(store, table, 5, true);
+  check_table(store, table, 6, true);
 
-  check(! wasm_table_grow(table, 5, NULL));
-  check(wasm_table_grow(table, 3, NULL));
-  check(wasm_table_grow(table, 0, NULL));
+  check(! wasm_table_grow_funcref(store, table, 5, NULL, &success) && !success);
+  check(! wasm_table_grow_funcref(store, table, 3, NULL, &success) && success);
+  check(! wasm_table_grow_funcref(store, table, 0, NULL, &success) && success);
 
   wasm_func_delete(h);
   wasm_extern_vec_delete(&exports);
@@ -194,10 +211,10 @@ int main(int argc, const char* argv[]) {
   wasm_limits_t limits = {5, 5};
   own wasm_tabletype_t* tabletype =
     wasm_tabletype_new(wasm_valtype_new(WASM_FUNCREF), &limits);
-  own wasm_table_t* table2 = wasm_table_new(store, tabletype, NULL);
+  own wasm_table_t* table2 = wasm_table_new(store, tabletype, NULL, &trap);
   check(wasm_table_size(table2) == 5);
-  check(! wasm_table_grow(table2, 1, NULL));
-  check(wasm_table_grow(table2, 0, NULL));
+  check(! wasm_table_grow(store, table2, 1, NULL, &success) && !success);
+  check(! wasm_table_grow(store, table2, 0, NULL, &success) && success);
 
   wasm_tabletype_delete(tabletype);
   wasm_table_delete(table2);

--- a/example/table.c
+++ b/example/table.c
@@ -57,7 +57,12 @@ void check_call(wasm_store_t* store, wasm_func_t* func, int32_t arg1, int32_t ar
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
   wasm_val_t results[1];
-  own wasm_trap_t *trap = wasm_func_call(store, func, args, array_len(args), results, array_len(results));
+  own wasm_trap_t *trap = wasm_func_call(
+                            store,
+                            func,
+                            (wasm_val_vec_t) { array_len(args), args },
+                            (wasm_val_vec_t) { array_len(results), results }
+                          );
   if (trap ||
       results[0].of.i32 != expected)
   {
@@ -71,7 +76,12 @@ void check_trap(wasm_store_t* store, wasm_func_t* func, int32_t arg1, int32_t ar
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  own wasm_trap_t* trap = wasm_func_call(store, func, args, array_len(args), NULL, 0);
+  own wasm_trap_t* trap = wasm_func_call(
+                            store,
+                            func,
+                            (wasm_val_vec_t) { array_len(args), args },
+                            (wasm_val_vec_t) { 0, NULL }
+                          );
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);
@@ -116,7 +126,12 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, 0, NULL);
+  own wasm_instance_t* instance = wasm_instance_new(
+                                    store,
+                                    module,
+                                    (wasm_extern_vec_t) { 0, NULL },
+                                    NULL
+                                  );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/threads.c
+++ b/example/threads.c
@@ -52,11 +52,16 @@ void* run(void* args_abs) {
     wasm_globaltype_delete(global_type);
 
     // Instantiate.
-    const wasm_extern_t* imports[] = {
+    wasm_extern_t* imports[] = {
       wasm_func_as_extern(func), wasm_global_as_extern(global),
     };
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, imports, array_len(imports), NULL);
+      wasm_instance_new(
+        store,
+        module,
+        (wasm_extern_vec_t) { array_len(imports), imports },
+        NULL
+      );
     if (!instance) {
       printf("> Error instantiating module!\n");
       return NULL;
@@ -81,7 +86,13 @@ void* run(void* args_abs) {
     wasm_instance_delete(instance);
 
     // Call.
-    if (wasm_func_call(store, run_func, NULL, 0, NULL, 0)) {
+    if (wasm_func_call(
+          store,
+          run_func,
+          (wasm_val_vec_t) { 0, NULL },
+          (wasm_val_vec_t) { 0, NULL }
+        )
+    ) {
       printf("> Error calling function!\n");
       return NULL;
     }

--- a/example/trap.c
+++ b/example/trap.c
@@ -77,9 +77,14 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, array_len(imports), NULL);
+    wasm_instance_new(
+      store,
+      module,
+      (wasm_extern_vec_t) { array_len(imports), imports },
+      NULL
+    );
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -108,7 +113,12 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    own wasm_trap_t* trap = wasm_func_call(store, func, NULL, 0, NULL, 0);
+    own wasm_trap_t* trap = wasm_func_call(
+                              store,
+                              func,
+                              (wasm_val_vec_t) { 0, NULL },
+                              (wasm_val_vec_t) { 0, NULL }
+                            );
     if (!trap) {
       printf("> Error calling function, expected trap!\n");
       return 1;

--- a/example/trap.c
+++ b/example/trap.c
@@ -16,7 +16,7 @@ own wasm_trap_t* fail_callback(
   printf("Calling back...\n");
   own wasm_name_t message;
   wasm_name_new_from_string(&message, "callback abort");
-  own wasm_trap_t* trap = wasm_trap_new((wasm_store_t*)env, &message);
+  own wasm_trap_t* trap = wasm_trap_new((wasm_store_t*)env, &message, false);
   wasm_name_delete(&message);
   return trap;
 }

--- a/example/trap.c
+++ b/example/trap.c
@@ -7,6 +7,8 @@
 
 #define own
 
+#define array_len(a) (sizeof(a) / sizeof((a)[0]))
+
 // A function to be called from Wasm code.
 own wasm_trap_t* fail_callback(
   void* env, const wasm_val_t args[], wasm_val_t results[]
@@ -77,7 +79,7 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   const wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, imports, array_len(imports), NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -106,7 +108,7 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    own wasm_trap_t* trap = wasm_func_call(func, NULL, NULL);
+    own wasm_trap_t* trap = wasm_func_call(store, func, NULL, 0, NULL, 0);
     if (!trap) {
       printf("> Error calling function, expected trap!\n");
       return 1;

--- a/include/wasm-emboldened.h
+++ b/include/wasm-emboldened.h
@@ -1,0 +1,244 @@
+// WebAssembly C "emboldened" API. These functions abort in debug builds
+// (when NDEBUG is not defined), and have undefined behavior in release
+// builds (when NDEBUG is defined), if attempts are made to violate wasm
+// invariants.
+
+#ifndef WASM_EMBOLDENED_H
+#define WASM_EMBOLDENED_H
+
+#include "wasm-unchecked.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// See the comments in "wasm.h".
+#define own
+
+///////////////////////////////////////////////////////////////////////////////
+
+static inline own wasm_trap_t* wasm_func_call_emboldened(
+  wasm_store_t* store,
+  const wasm_func_t* func,
+  wasm_val_vec_t args,
+  wasm_val_vec_t results)
+{
+#ifndef NDEBUG
+  return wasm_func_call(store, func, args, results);
+#else
+  return wasm_func_call_unchecked(func, args.data, results.data);
+#endif
+}
+
+static inline own wasm_global_t* wasm_global_new_emboldened(
+  wasm_store_t* store,
+  const wasm_globaltype_t* type,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_global_t* global = wasm_global_new(store, type, val, &trap);
+  assert(global || !trap);
+  return global;
+#else
+  return wasm_global_new_unchecked(store, type, val);
+#endif
+}
+
+static inline void wasm_global_set_emboldened(
+  wasm_store_t* store,
+  wasm_global_t* global,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  assert(!wasm_global_set(store, global, val));
+#else
+  wasm_global_set_unchecked(global, val);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  const wasm_val_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_anyref_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new_anyref(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_anyref_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_funcref_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new_funcref(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_funcref_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_ref_t* wasm_table_get_anyref_emboldened(
+  wasm_store_t* store,
+  const wasm_table_t* table,
+  wasm_table_size_t index,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_table_get_anyref(store, table, index, trap);
+#else
+  return wasm_table_get_anyref_unchecked(store, table, index, trap);
+#endif
+}
+
+static inline own wasm_ref_t* wasm_table_get_funcref_emboldened(
+  wasm_store_t* store,
+  const wasm_table_t* table,
+  wasm_table_size_t index,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_table_get_funcref(store, table, index, trap);
+#else
+  return wasm_table_get_funcref_unchecked(store, table, index, trap);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  return wasm_table_set(store, table, index, val);
+#else
+  return wasm_table_set_unchecked(store, table, index, val);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_anyref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  wasm_ref_t* ref)
+{
+#ifndef NDEBUG
+  return wasm_table_set_anyref(store, table, index, ref);
+#else
+  return wasm_table_set_anyref_unchecked(store, table, index, ref);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_funcref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  wasm_ref_t* ref)
+{
+#ifndef NDEBUG
+  return wasm_table_set_funcref(store, table, index, ref);
+#else
+  return wasm_table_set_funcref_unchecked(store, table, index, ref);
+#endif
+}
+
+static inline bool wasm_table_grow_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  const wasm_val_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap = wasm_table_grow(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_unchecked(table, delta, init);
+#endif
+}
+
+static inline bool wasm_table_grow_anyref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap =
+    wasm_table_grow_anyref(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_anyref_unchecked(table, delta, init);
+#endif
+}
+
+static inline bool wasm_table_grow_funcref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap =
+    wasm_table_grow_funcref(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_funcref_unchecked(table, delta, init);
+#endif
+}
+
+static inline own wasm_instance_t* wasm_instance_new_emboldened(
+  wasm_store_t* store,
+  const wasm_module_t* module,
+  wasm_extern_vec_t imports,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_instance_new(store, module, imports, trap);
+#else
+  return wasm_instance_new_unchecked(store, module, imports.data, trap);
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#undef own
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // #ifdef WASM_EMBOLDENED_H

--- a/include/wasm-emboldened.h
+++ b/include/wasm-emboldened.h
@@ -38,7 +38,7 @@ static inline own wasm_global_t* wasm_global_new_emboldened(
 #ifndef NDEBUG
   own wasm_trap_t* trap;
   own wasm_global_t* global = wasm_global_new(store, type, val, &trap);
-  assert(global || !trap);
+  assert(global || !trap || !wasm_trap_is_compile_error(trap));
   return global;
 #else
   return wasm_global_new_unchecked(store, type, val);
@@ -65,7 +65,7 @@ static inline own wasm_table_t* wasm_table_new_emboldened(
 #ifndef NDEBUG
   own wasm_trap_t* trap;
   own wasm_table_t* table = wasm_table_new(store, type, init, &trap);
-  assert(table || !trap);
+  assert(table || !trap || !wasm_trap_is_compile_error(trap));
   return table;
 #else
   return wasm_table_new_unchecked(store, type, init);
@@ -80,7 +80,7 @@ static inline own wasm_table_t* wasm_table_new_anyref_emboldened(
 #ifndef NDEBUG
   own wasm_trap_t* trap;
   own wasm_table_t* table = wasm_table_new_anyref(store, type, init, &trap);
-  assert(table || !trap);
+  assert(table || !trap || !wasm_trap_is_compile_error(trap));
   return table;
 #else
   return wasm_table_new_anyref_unchecked(store, type, init);
@@ -95,7 +95,7 @@ static inline own wasm_table_t* wasm_table_new_funcref_emboldened(
 #ifndef NDEBUG
   own wasm_trap_t* trap;
   own wasm_table_t* table = wasm_table_new_funcref(store, type, init, &trap);
-  assert(table || !trap);
+  assert(table || !trap || !wasm_trap_is_compile_error(trap));
   return table;
 #else
   return wasm_table_new_funcref_unchecked(store, type, init);

--- a/include/wasm-unchecked.h
+++ b/include/wasm-unchecked.h
@@ -1,0 +1,171 @@
+// WebAssembly C unchecked API. These functions exhibit undefined behavior
+// if attempts are made to violate wasm invariants.
+
+#ifndef WASM_UNCHECKED_H
+#define WASM_UNCHECKED_H
+
+#include "wasm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// See the comments in "wasm.h".
+#define own
+
+/// Similar to `wasm_func_call`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_func_call_unchecked(
+  const wasm_func_t*,
+  const wasm_val_t args[],
+  wasm_val_t results[]);
+
+/// Similar to `wasm_global_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_global_t* wasm_global_new_unchecked(
+  wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
+
+/// Similar to `wasm_global_set`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN void wasm_global_set_unchecked(wasm_global_t*, const wasm_val_t*);
+
+/// Similar to `wasm_table_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_unchecked(
+  wasm_store_t*, const wasm_tabletype_t*, const wasm_val_t* init);
+
+/// Similar to `wasm_table_new_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_anyref_unchecked(
+  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
+
+/// Similar to `wasm_table_new_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_funcref_unchecked(
+  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
+
+/// Similar to `wasm_table_get_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_anyref_unchecked(
+  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Similar to `wasm_table_get_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_funcref_unchecked(
+  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Similar to `wasm_table_set`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, const wasm_val_t*
+);
+
+/// Similar to `wasm_table_set_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_anyref_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
+
+/// Similar to `wasm_table_set_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_funcref_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
+
+/// Similar to `wasm_table_grow`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, const wasm_val_t* init
+);
+
+/// Similar to `wasm_table_grow_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_anyref_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
+);
+
+/// Similar to `wasm_table_grow_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_funcref_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
+);
+
+/// Similar to `wasm_instance_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_unchecked(
+  wasm_store_t*, const wasm_module_t*,
+  const wasm_extern_t* const imports[],
+  own wasm_trap_t** trap
+);
+
+///////////////////////////////////////////////////////////////////////////////
+
+#undef own
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // #ifdef WASM_UNCHECKED_H

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -373,8 +373,13 @@ typedef wasm_name_t wasm_message_t;  // null terminated
 
 WASM_DECLARE_REF(trap)
 
-WASM_API_EXTERN own wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t*);
+WASM_API_EXTERN own wasm_trap_t* wasm_trap_new(
+  wasm_store_t* store,
+  const wasm_message_t*,
+  bool is_compile_time
+);
 
+WASM_API_EXTERN bool wasm_trap_is_compile_error(const wasm_trap_t*);
 WASM_API_EXTERN void wasm_trap_message(const wasm_trap_t*, own wasm_message_t* out);
 WASM_API_EXTERN own wasm_frame_t* wasm_trap_origin(const wasm_trap_t*);
 WASM_API_EXTERN void wasm_trap_trace(const wasm_trap_t*, own wasm_frame_vec_t* out);

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -440,17 +440,6 @@ WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
   wasm_val_vec_t args,
   wasm_val_vec_t results);
 
-/// Similar to `wasm_func_call`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_trap_t* wasm_func_call_unchecked(
-  const wasm_func_t*,
-  const wasm_val_t args[],
-  wasm_val_t results[]);
-
 
 // Global Instances
 
@@ -465,15 +454,6 @@ WASM_DECLARE_REF(global)
 WASM_API_EXTERN own wasm_global_t* wasm_global_new(
   wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*, own wasm_trap_t**);
 
-/// Similar to `wasm_global_new`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_global_t* wasm_global_new_unchecked(
-  wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
-
 WASM_API_EXTERN own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
 WASM_API_EXTERN void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
@@ -485,14 +465,6 @@ WASM_API_EXTERN void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
 /// This function returns an error if the global is immutable or if
 /// the new value has a type with a different `wasm_valkind_t` than the global.
 WASM_API_EXTERN own wasm_trap_t* wasm_global_set(wasm_store_t*, wasm_global_t*, const wasm_val_t*);
-
-/// Similar to `wasm_global_set`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN void wasm_global_set_unchecked(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances
@@ -528,33 +500,6 @@ WASM_API_EXTERN own wasm_table_t* wasm_table_new_anyref(
 WASM_API_EXTERN own wasm_table_t* wasm_table_new_funcref(
   wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init,
   own wasm_trap_t** trap);
-
-/// Similar to `wasm_table_new`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_table_t* wasm_table_new_unchecked(
-  wasm_store_t*, const wasm_tabletype_t*, const wasm_val_t* init);
-
-/// Similar to `wasm_table_new_anyref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_table_t* wasm_table_new_anyref_unchecked(
-  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
-
-/// Similar to `wasm_table_new_funcref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_table_t* wasm_table_new_funcref_unchecked(
-  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
 
 WASM_API_EXTERN own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
@@ -593,26 +538,6 @@ WASM_API_EXTERN own wasm_ref_t* wasm_table_get_anyref(
 ///
 /// This function returns an error if the table's element type is not funcref.
 WASM_API_EXTERN own wasm_ref_t* wasm_table_get_funcref(
-  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
-);
-
-/// Similar to `wasm_table_get_anyref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_ref_t* wasm_table_get_anyref_unchecked(
-  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
-);
-
-/// Similar to `wasm_table_get_funcref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_ref_t* wasm_table_get_funcref_unchecked(
   wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
 );
 
@@ -657,36 +582,6 @@ WASM_API_EXTERN own wasm_trap_t* wasm_table_set_funcref(
   wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
 );
 
-/// Similar to `wasm_table_set`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_trap_t* wasm_table_set_unchecked(
-  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, const wasm_val_t*
-);
-
-/// Similar to `wasm_table_set_anyref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_trap_t* wasm_table_set_anyref_unchecked(
-  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
-);
-
-/// Similar to `wasm_table_set_funcref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_trap_t* wasm_table_set_funcref_unchecked(
-  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
-);
-
 WASM_API_EXTERN wasm_table_size_t wasm_table_size(const wasm_table_t*);
 
 /// Increase the size of a table. Set *success to false if memory allocation fails.
@@ -727,36 +622,6 @@ WASM_API_EXTERN own wasm_trap_t* wasm_table_grow_anyref(
 WASM_API_EXTERN own wasm_trap_t* wasm_table_grow_funcref(
   wasm_store_t*, wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init,
   bool* success
-);
-
-/// Similar to `wasm_table_grow`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN bool wasm_table_grow_unchecked(
-  wasm_table_t*, wasm_table_size_t delta, const wasm_val_t* init
-);
-
-/// Similar to `wasm_table_grow_anyref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN bool wasm_table_grow_anyref_unchecked(
-  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
-);
-
-/// Similar to `wasm_table_grow_funcref`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN bool wasm_table_grow_funcref_unchecked(
-  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
 );
 
 
@@ -827,18 +692,6 @@ WASM_DECLARE_REF(instance)
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*,
   wasm_extern_vec_t imports,
-  own wasm_trap_t** trap
-);
-
-/// Similar to `wasm_instance_new`, but with undefined behavior instead of
-/// reporting errors.
-///
-/// # Safety
-///
-/// This function has undefined behavior in response to any errors.
-WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_unchecked(
-  wasm_store_t*, const wasm_module_t*,
-  const wasm_extern_t* const imports[],
   own wasm_trap_t** trap
 );
 
@@ -1017,227 +870,6 @@ static inline void* wasm_val_ptr(const wasm_val_t* val) {
   return (void*)(intptr_t)val->of.i32;
 #elif UINTPTR_MAX == UINT64_MAX
   return (void*)(intptr_t)val->of.i64;
-#endif
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Wrappers around the `_unchecked` APIs which which enable extra error
-// checking when `NDEBUG` is not predefined.
-
-static inline own wasm_trap_t* wasm_func_call_emboldened(
-  wasm_store_t* store,
-  const wasm_func_t* func,
-  wasm_val_vec_t args,
-  wasm_val_vec_t results)
-{
-#ifndef NDEBUG
-  return wasm_func_call(store, func, args, results);
-#else
-  return wasm_func_call_unchecked(func, args.data, results.data);
-#endif
-}
-
-static inline own wasm_global_t* wasm_global_new_emboldened(
-  wasm_store_t* store,
-  const wasm_globaltype_t* type,
-  const wasm_val_t* val)
-{
-#ifndef NDEBUG
-  own wasm_trap_t* trap;
-  own wasm_global_t* global = wasm_global_new(store, type, val, &trap);
-  assert(global || !trap);
-  return global;
-#else
-  return wasm_global_new_unchecked(store, type, val);
-#endif
-}
-
-static inline void wasm_global_set_emboldened(
-  wasm_store_t* store,
-  wasm_global_t* global,
-  const wasm_val_t* val)
-{
-#ifndef NDEBUG
-  assert(!wasm_global_set(store, global, val));
-#else
-  wasm_global_set_unchecked(global, val);
-#endif
-}
-
-static inline own wasm_table_t* wasm_table_new_emboldened(
-  wasm_store_t* store,
-  const wasm_tabletype_t* type,
-  const wasm_val_t* init)
-{
-#ifndef NDEBUG
-  own wasm_trap_t* trap;
-  own wasm_table_t* table = wasm_table_new(store, type, init, &trap);
-  assert(table || !trap);
-  return table;
-#else
-  return wasm_table_new_unchecked(store, type, init);
-#endif
-}
-
-static inline own wasm_table_t* wasm_table_new_anyref_emboldened(
-  wasm_store_t* store,
-  const wasm_tabletype_t* type,
-  wasm_ref_t* init)
-{
-#ifndef NDEBUG
-  own wasm_trap_t* trap;
-  own wasm_table_t* table = wasm_table_new_anyref(store, type, init, &trap);
-  assert(table || !trap);
-  return table;
-#else
-  return wasm_table_new_anyref_unchecked(store, type, init);
-#endif
-}
-
-static inline own wasm_table_t* wasm_table_new_funcref_emboldened(
-  wasm_store_t* store,
-  const wasm_tabletype_t* type,
-  wasm_ref_t* init)
-{
-#ifndef NDEBUG
-  own wasm_trap_t* trap;
-  own wasm_table_t* table = wasm_table_new_funcref(store, type, init, &trap);
-  assert(table || !trap);
-  return table;
-#else
-  return wasm_table_new_funcref_unchecked(store, type, init);
-#endif
-}
-
-static inline own wasm_ref_t* wasm_table_get_anyref_emboldened(
-  wasm_store_t* store,
-  const wasm_table_t* table,
-  wasm_table_size_t index,
-  own wasm_trap_t** trap)
-{
-#ifndef NDEBUG
-  return wasm_table_get_anyref(store, table, index, trap);
-#else
-  return wasm_table_get_anyref_unchecked(store, table, index, trap);
-#endif
-}
-
-static inline own wasm_ref_t* wasm_table_get_funcref_emboldened(
-  wasm_store_t* store,
-  const wasm_table_t* table,
-  wasm_table_size_t index,
-  own wasm_trap_t** trap)
-{
-#ifndef NDEBUG
-  return wasm_table_get_funcref(store, table, index, trap);
-#else
-  return wasm_table_get_funcref_unchecked(store, table, index, trap);
-#endif
-}
-
-static inline own wasm_trap_t* wasm_table_set_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t index,
-  const wasm_val_t* val)
-{
-#ifndef NDEBUG
-  return wasm_table_set(store, table, index, val);
-#else
-  return wasm_table_set_unchecked(store, table, index, val);
-#endif
-}
-
-static inline own wasm_trap_t* wasm_table_set_anyref_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t index,
-  wasm_ref_t* ref)
-{
-#ifndef NDEBUG
-  return wasm_table_set_anyref(store, table, index, ref);
-#else
-  return wasm_table_set_anyref_unchecked(store, table, index, ref);
-#endif
-}
-
-static inline own wasm_trap_t* wasm_table_set_funcref_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t index,
-  wasm_ref_t* ref)
-{
-#ifndef NDEBUG
-  return wasm_table_set_funcref(store, table, index, ref);
-#else
-  return wasm_table_set_funcref_unchecked(store, table, index, ref);
-#endif
-}
-
-static inline bool wasm_table_grow_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t delta,
-  const wasm_val_t* init)
-{
-#ifndef NDEBUG
-  bool success;
-  own wasm_trap_t* trap = wasm_table_grow(store, table, delta, init, &success);
-  assert(!trap);
-  return success;
-#else
-  (void) store;
-  return wasm_table_grow_unchecked(table, delta, init);
-#endif
-}
-
-static inline bool wasm_table_grow_anyref_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t delta,
-  wasm_ref_t* init)
-{
-#ifndef NDEBUG
-  bool success;
-  own wasm_trap_t* trap =
-    wasm_table_grow_anyref(store, table, delta, init, &success);
-  assert(!trap);
-  return success;
-#else
-  (void) store;
-  return wasm_table_grow_anyref_unchecked(table, delta, init);
-#endif
-}
-
-static inline bool wasm_table_grow_funcref_emboldened(
-  wasm_store_t* store,
-  wasm_table_t* table,
-  wasm_table_size_t delta,
-  wasm_ref_t* init)
-{
-#ifndef NDEBUG
-  bool success;
-  own wasm_trap_t* trap =
-    wasm_table_grow_funcref(store, table, delta, init, &success);
-  assert(!trap);
-  return success;
-#else
-  (void) store;
-  return wasm_table_grow_funcref_unchecked(table, delta, init);
-#endif
-}
-
-static inline own wasm_instance_t* wasm_instance_new_emboldened(
-  wasm_store_t* store,
-  const wasm_module_t* module,
-  wasm_extern_vec_t imports,
-  own wasm_trap_t** trap)
-{
-#ifndef NDEBUG
-  return wasm_instance_new(store, module, imports, trap);
-#else
-  return wasm_instance_new_unchecked(store, module, imports.data, trap);
 #endif
 }
 

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -422,21 +422,77 @@ WASM_API_EXTERN own wasm_functype_t* wasm_func_type(const wasm_func_t*);
 WASM_API_EXTERN size_t wasm_func_param_arity(const wasm_func_t*);
 WASM_API_EXTERN size_t wasm_func_result_arity(const wasm_func_t*);
 
+/// Call a wasm function.
+///
+/// # Traps
+///
+/// The called function may trap.
+///
+/// # Errors
+///
+/// This function returns an error if the `args` or `results` arrays
+/// have the wrong length for the function's signature, or if any of
+/// the types of the argument values or return values don't conform
+/// to the function's signature.
 WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
-  const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
+  wasm_store_t* store,
+  const wasm_func_t*,
+  const wasm_val_t args[], size_t num_args,
+  wasm_val_t results[], size_t num_results);
+
+/// Similar to `wasm_func_call`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_func_call_unchecked(
+  const wasm_func_t*,
+  const wasm_val_t args[],
+  wasm_val_t results[]);
 
 
 // Global Instances
 
 WASM_DECLARE_REF(global)
 
+/// Create a new global variable.
+///
+/// # Errors
+///
+/// This function returns an error if the initial value has a type with a
+/// different `wasm_valkind_t` than the global.
 WASM_API_EXTERN own wasm_global_t* wasm_global_new(
+  wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*, own wasm_trap_t**);
+
+/// Similar to `wasm_global_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_global_t* wasm_global_new_unchecked(
   wasm_store_t*, const wasm_globaltype_t*, const wasm_val_t*);
 
 WASM_API_EXTERN own wasm_globaltype_t* wasm_global_type(const wasm_global_t*);
 
 WASM_API_EXTERN void wasm_global_get(const wasm_global_t*, own wasm_val_t* out);
-WASM_API_EXTERN void wasm_global_set(wasm_global_t*, const wasm_val_t*);
+
+/// Assign a new value to a global variable.
+///
+/// # Errors
+///
+/// This function returns an error if the global is immutable or if
+/// the new value has a type with a different `wasm_valkind_t` than the global.
+WASM_API_EXTERN own wasm_trap_t* wasm_global_set(wasm_store_t*, wasm_global_t*, const wasm_val_t*);
+
+/// Similar to `wasm_global_set`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN void wasm_global_set_unchecked(wasm_global_t*, const wasm_val_t*);
 
 
 // Table Instances
@@ -445,16 +501,263 @@ WASM_DECLARE_REF(table)
 
 typedef uint32_t wasm_table_size_t;
 
+/// Create a new table. Return NULL and set *trap if an error occurred.
+///
+/// # Errors
+///
+/// This function returns an error if the new value has a type with a different
+/// `wasm_valkind_t` than the table's element type.
 WASM_API_EXTERN own wasm_table_t* wasm_table_new(
+  wasm_store_t*, const wasm_tabletype_t*, const wasm_val_t* init,
+  own wasm_trap_t** trap);
+
+/// Specialized form of `wasm_table_new` for anyref tables.
+///
+/// # Errors
+///
+/// This function returns an error if the new value type is not anyref.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_anyref(
+  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init,
+  own wasm_trap_t** trap);
+
+/// Specialized form of `wasm_table_new` for funcref tables.
+///
+/// # Errors
+///
+/// This function returns an error if the new value type is not funcref.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_funcref(
+  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init,
+  own wasm_trap_t** trap);
+
+/// Similar to `wasm_table_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_unchecked(
+  wasm_store_t*, const wasm_tabletype_t*, const wasm_val_t* init);
+
+/// Similar to `wasm_table_new_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_anyref_unchecked(
+  wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
+
+/// Similar to `wasm_table_new_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_table_t* wasm_table_new_funcref_unchecked(
   wasm_store_t*, const wasm_tabletype_t*, wasm_ref_t* init);
 
 WASM_API_EXTERN own wasm_tabletype_t* wasm_table_type(const wasm_table_t*);
 
-WASM_API_EXTERN own wasm_ref_t* wasm_table_get(const wasm_table_t*, wasm_table_size_t index);
-WASM_API_EXTERN bool wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*);
+/// Retrieve the value of an element of a table. Returns non-NULL if a runtime
+/// trap occurred.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_get(wasm_store_t*, const wasm_table_t*,
+                                                wasm_table_size_t index, own wasm_val_t*);
+
+/// Retrieve the anyref value of an element of a table. Return NULL and set *trap if a
+/// runtime trap or error occurred.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+///
+/// # Errors
+///
+/// This function returns an error if the table's element type is not anyref.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_anyref(
+  wasm_store_t*, const wasm_table_t*,
+  wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Retrieve the funcref value of an element of a table. Return NULL and set *trap if a
+/// runtime trap or error occurred.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+///
+/// # Errors
+///
+/// This function returns an error if the table's element type is not funcref.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_funcref(
+  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Similar to `wasm_table_get_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_anyref_unchecked(
+  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Similar to `wasm_table_get_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_ref_t* wasm_table_get_funcref_unchecked(
+  wasm_store_t*, const wasm_table_t*, wasm_table_size_t index, own wasm_trap_t** trap
+);
+
+/// Assign a new value to an element of a table. Returns non-NULL if a runtime
+/// trap or error occurred.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+///
+/// # Errors
+///
+/// This function returns an error if the new value has a type with a different
+/// `wasm_valkind_t` than the table's element type.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, const wasm_val_t*
+);
+
+/// Specialized form of `wasm_table_set` for anyref tables.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+///
+/// # Errors
+///
+/// This function returns an error if the table element type is not anyref.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_anyref(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
+
+/// Specialized form of `wasm_table_set` for funcref tables.
+///
+/// # Traps
+///
+/// This function traps if the index is out of bounds in the table.
+///
+/// # Errors
+///
+/// This function returns an error if the table element type is not funcref.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_funcref(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
+
+/// Similar to `wasm_table_set`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, const wasm_val_t*
+);
+
+/// Similar to `wasm_table_set_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_anyref_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
+
+/// Similar to `wasm_table_set_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_set_funcref_unchecked(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t index, wasm_ref_t*
+);
 
 WASM_API_EXTERN wasm_table_size_t wasm_table_size(const wasm_table_t*);
-WASM_API_EXTERN bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init);
+
+/// Increase the size of a table. Set *success to false if memory allocation fails.
+///
+/// TODO: The signature should probably change to more closely reflect wasm
+/// `table.grow` semantics of returning the old size.
+///
+/// # Errors
+///
+/// This function returns an error if the new value has a type with a different
+/// `wasm_valkind_t` than the table's element type.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_grow(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t delta,
+  const wasm_val_t* init, bool* success
+);
+
+/// Specialized form of `wasm_table_grow` for anyref tables.
+///
+/// TODO: The signature should probably change to more closely reflect wasm
+/// `table.grow` semantics of returning the old size.
+///
+/// # Errors
+///
+/// This function returns an error if the new value type is not anyref.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_grow_anyref(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init,
+  bool* success
+);
+
+/// Specialized form of `wasm_table_grow` for funcref tables.
+///
+/// TODO: The signature should probably change to more closely reflect wasm
+/// `table.grow` semantics of returning the old size.
+///
+/// # Errors
+///
+/// This function returns an error if the new value type is not funcref.
+WASM_API_EXTERN own wasm_trap_t* wasm_table_grow_funcref(
+  wasm_store_t*, wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init,
+  bool* success
+);
+
+/// Similar to `wasm_table_grow`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, const wasm_val_t* init
+);
+
+/// Similar to `wasm_table_grow_anyref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_anyref_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
+);
+
+/// Similar to `wasm_table_grow_funcref`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN bool wasm_table_grow_funcref_unchecked(
+  wasm_table_t*, wasm_table_size_t delta, wasm_ref_t* init
+);
 
 
 // Memory Instances
@@ -509,9 +812,34 @@ WASM_API_EXTERN const wasm_memory_t* wasm_extern_as_memory_const(const wasm_exte
 
 WASM_DECLARE_REF(instance)
 
+/// Create a new instance of a module. Return NULL and set *trap if a runtime
+/// trap or error occurred.
+///
+/// # Traps
+///
+/// If the module contains a start section, the function identified in the start
+/// section is executed, and it may trap.
+///
+/// # Errors
+///
+/// This function returns an error if the size of the `imports` array
+/// doesn't match the number of imports in the module.
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
-  wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
-  own wasm_trap_t**
+  wasm_store_t*, const wasm_module_t*,
+  const wasm_extern_t* const imports[], size_t num_imports,
+  own wasm_trap_t** trap
+);
+
+/// Similar to `wasm_instance_new`, but with undefined behavior instead of
+/// reporting errors.
+///
+/// # Safety
+///
+/// This function has undefined behavior in response to any errors.
+WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_unchecked(
+  wasm_store_t*, const wasm_module_t*,
+  const wasm_extern_t* const imports[],
+  own wasm_trap_t** trap
 );
 
 WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -437,8 +437,8 @@ WASM_API_EXTERN size_t wasm_func_result_arity(const wasm_func_t*);
 WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
   wasm_store_t* store,
   const wasm_func_t*,
-  const wasm_val_t args[], size_t num_args,
-  wasm_val_t results[], size_t num_results);
+  wasm_val_vec_t args,
+  wasm_val_vec_t results);
 
 /// Similar to `wasm_func_call`, but with undefined behavior instead of
 /// reporting errors.
@@ -826,7 +826,7 @@ WASM_DECLARE_REF(instance)
 /// doesn't match the number of imports in the module.
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*,
-  const wasm_extern_t* const imports[], size_t num_imports,
+  wasm_extern_vec_t imports,
   own wasm_trap_t** trap
 );
 
@@ -1028,13 +1028,13 @@ static inline void* wasm_val_ptr(const wasm_val_t* val) {
 static inline own wasm_trap_t* wasm_func_call_emboldened(
   wasm_store_t* store,
   const wasm_func_t* func,
-  const wasm_val_t args[], size_t num_args,
-  wasm_val_t results[], size_t num_results)
+  wasm_val_vec_t args,
+  wasm_val_vec_t results)
 {
 #ifndef NDEBUG
-  return wasm_func_call(store, func, args, num_args, results, num_results);
+  return wasm_func_call(store, func, args, results);
 #else
-  return wasm_func_call_unchecked(func, args, results);
+  return wasm_func_call_unchecked(func, args.data, results.data);
 #endif
 }
 
@@ -1231,14 +1231,13 @@ static inline bool wasm_table_grow_funcref_emboldened(
 static inline own wasm_instance_t* wasm_instance_new_emboldened(
   wasm_store_t* store,
   const wasm_module_t* module,
-  const wasm_extern_t* const imports[],
-  size_t num_imports,
+  wasm_extern_vec_t imports,
   own wasm_trap_t** trap)
 {
 #ifndef NDEBUG
-  return wasm_instance_new(store, module, imports, num_imports, trap);
+  return wasm_instance_new(store, module, imports, trap);
 #else
-  return wasm_instance_new_unchecked(store, module, imports, trap);
+  return wasm_instance_new_unchecked(store, module, imports.data, trap);
 #endif
 }
 

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -1022,6 +1022,227 @@ static inline void* wasm_val_ptr(const wasm_val_t* val) {
 
 
 ///////////////////////////////////////////////////////////////////////////////
+// Wrappers around the `_unchecked` APIs which which enable extra error
+// checking when `NDEBUG` is not predefined.
+
+static inline own wasm_trap_t* wasm_func_call_emboldened(
+  wasm_store_t* store,
+  const wasm_func_t* func,
+  const wasm_val_t args[], size_t num_args,
+  wasm_val_t results[], size_t num_results)
+{
+#ifndef NDEBUG
+  return wasm_func_call(store, func, args, num_args, results, num_results);
+#else
+  return wasm_func_call_unchecked(func, args, results);
+#endif
+}
+
+static inline own wasm_global_t* wasm_global_new_emboldened(
+  wasm_store_t* store,
+  const wasm_globaltype_t* type,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_global_t* global = wasm_global_new(store, type, val, &trap);
+  assert(global || !trap);
+  return global;
+#else
+  return wasm_global_new_unchecked(store, type, val);
+#endif
+}
+
+static inline void wasm_global_set_emboldened(
+  wasm_store_t* store,
+  wasm_global_t* global,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  assert(!wasm_global_set(store, global, val));
+#else
+  wasm_global_set_unchecked(global, val);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  const wasm_val_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_anyref_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new_anyref(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_anyref_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_table_t* wasm_table_new_funcref_emboldened(
+  wasm_store_t* store,
+  const wasm_tabletype_t* type,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  own wasm_trap_t* trap;
+  own wasm_table_t* table = wasm_table_new_funcref(store, type, init, &trap);
+  assert(table || !trap);
+  return table;
+#else
+  return wasm_table_new_funcref_unchecked(store, type, init);
+#endif
+}
+
+static inline own wasm_ref_t* wasm_table_get_anyref_emboldened(
+  wasm_store_t* store,
+  const wasm_table_t* table,
+  wasm_table_size_t index,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_table_get_anyref(store, table, index, trap);
+#else
+  return wasm_table_get_anyref_unchecked(store, table, index, trap);
+#endif
+}
+
+static inline own wasm_ref_t* wasm_table_get_funcref_emboldened(
+  wasm_store_t* store,
+  const wasm_table_t* table,
+  wasm_table_size_t index,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_table_get_funcref(store, table, index, trap);
+#else
+  return wasm_table_get_funcref_unchecked(store, table, index, trap);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  const wasm_val_t* val)
+{
+#ifndef NDEBUG
+  return wasm_table_set(store, table, index, val);
+#else
+  return wasm_table_set_unchecked(store, table, index, val);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_anyref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  wasm_ref_t* ref)
+{
+#ifndef NDEBUG
+  return wasm_table_set_anyref(store, table, index, ref);
+#else
+  return wasm_table_set_anyref_unchecked(store, table, index, ref);
+#endif
+}
+
+static inline own wasm_trap_t* wasm_table_set_funcref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t index,
+  wasm_ref_t* ref)
+{
+#ifndef NDEBUG
+  return wasm_table_set_funcref(store, table, index, ref);
+#else
+  return wasm_table_set_funcref_unchecked(store, table, index, ref);
+#endif
+}
+
+static inline bool wasm_table_grow_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  const wasm_val_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap = wasm_table_grow(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_unchecked(table, delta, init);
+#endif
+}
+
+static inline bool wasm_table_grow_anyref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap =
+    wasm_table_grow_anyref(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_anyref_unchecked(table, delta, init);
+#endif
+}
+
+static inline bool wasm_table_grow_funcref_emboldened(
+  wasm_store_t* store,
+  wasm_table_t* table,
+  wasm_table_size_t delta,
+  wasm_ref_t* init)
+{
+#ifndef NDEBUG
+  bool success;
+  own wasm_trap_t* trap =
+    wasm_table_grow_funcref(store, table, delta, init, &success);
+  assert(!trap);
+  return success;
+#else
+  (void) store;
+  return wasm_table_grow_funcref_unchecked(table, delta, init);
+#endif
+}
+
+static inline own wasm_instance_t* wasm_instance_new_emboldened(
+  wasm_store_t* store,
+  const wasm_module_t* module,
+  const wasm_extern_t* const imports[],
+  size_t num_imports,
+  own wasm_trap_t** trap)
+{
+#ifndef NDEBUG
+  return wasm_instance_new(store, module, imports, num_imports, trap);
+#else
+  return wasm_instance_new_unchecked(store, module, imports, trap);
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 #undef own
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -558,9 +558,10 @@ public:
   Trap() = delete;
   ~Trap();
 
-  static auto make(Store*, const Message& msg) -> own<Trap>;
+  static auto make(Store*, const Message& msg, bool is_compile_error) -> own<Trap>;
   auto copy() const -> own<Trap>;
 
+  auto is_compile_error() const -> bool;
   auto message() const -> Message;
   auto origin() const -> own<Frame>;  // may be null
   auto trace() const -> ownvec<Frame>;  // may be empty, origin first

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -1,4 +1,5 @@
 #include "wasm.h"
+#include "wasm-unchecked.h"
 #include "wasm.hh"
 
 #include "wasm-v8.cc"

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -874,30 +874,30 @@ wasm_trap_t* wasm_func_call_unchecked(
 wasm_trap_t* wasm_func_call(
   wasm_store_t* store,
   const wasm_func_t* func,
-  const wasm_val_t args[], size_t num_args,
-  wasm_val_t results[], size_t num_results
+  const wasm_val_vec_t args,
+  wasm_val_vec_t results
 ) {
   wasm_functype_t* functype = wasm_func_type(func);
   const wasm_valtype_vec_t* param_types = wasm_functype_params(functype);
   const wasm_valtype_vec_t* result_types = wasm_functype_results(functype);
 
-  if (param_types->size != num_args) {
+  if (param_types->size != args.size) {
     wasm_functype_delete(functype);
     return wasm_invariant_violation(store, "wrong number of args");
   }
-  if (result_types->size != num_results) {
+  if (result_types->size != results.size) {
     wasm_functype_delete(functype);
     return wasm_invariant_violation(store, "wrong number of results");
   }
 
   for (size_t i = 0; i != param_types->size; ++i) {
-    if (wasm_valtype_kind(param_types->data[i]) != args[i].kind) {
+    if (wasm_valtype_kind(param_types->data[i]) != args.data[i].kind) {
       wasm_functype_delete(functype);
       return wasm_invariant_violation(store, "wrong argument type");
     }
   }
 
-  return wasm_func_call_unchecked(func, args, results);
+  return wasm_func_call_unchecked(func, args.data, results.data);
 }
 
 
@@ -1385,13 +1385,13 @@ wasm_instance_t* wasm_instance_new_unchecked(
 wasm_instance_t* wasm_instance_new(
   wasm_store_t* store,
   const wasm_module_t* module,
-  const wasm_extern_t* const imports[], size_t num_imports,
+  wasm_extern_vec_t imports,
   wasm_trap_t** trap
 ) {
   wasm_importtype_vec_t module_imports;
   wasm_module_imports(module, &module_imports);
 
-  if (module_imports.size != num_imports) {
+  if (module_imports.size != imports.size) {
     wasm_importtype_vec_delete(&module_imports);
     *trap = wasm_invariant_violation(store, "wrong number of imports");
     return NULL;
@@ -1399,7 +1399,7 @@ wasm_instance_t* wasm_instance_new(
 
   wasm_importtype_vec_delete(&module_imports);
 
-  return wasm_instance_new_unchecked(store, module, imports, trap);
+  return wasm_instance_new_unchecked(store, module, imports.data, trap);
 }
 
 void wasm_instance_exports(

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -690,9 +690,17 @@ size_t wasm_frame_module_offset(const wasm_frame_t* frame) {
 
 WASM_DEFINE_REF(trap, Trap)
 
-wasm_trap_t* wasm_trap_new(wasm_store_t* store, const wasm_message_t* message) {
+wasm_trap_t* wasm_trap_new(
+  wasm_store_t* store,
+  const wasm_message_t* message,
+  bool is_compile_time
+) {
   auto message_ = borrow_byte_vec(message);
-  return release_trap(Trap::make(store, message_.it));
+  return release_trap(Trap::make(store, message_.it, is_compile_time));
+}
+
+bool wasm_trap_is_compile_error(const wasm_trap_t* trap) {
+  return reveal_trap(trap)->is_compile_error();
 }
 
 void wasm_trap_message(const wasm_trap_t* trap, wasm_message_t* out) {
@@ -729,7 +737,7 @@ static wasm_trap_t* wasm_invariant_violation(wasm_store_t* store, const char *me
   wasm_name_t name;
   wasm_name_new_from_string(&name, (std::string("invariant violation: ") + message).c_str());
 
-  wasm_trap_t* error = wasm_trap_new(store, &name);
+  wasm_trap_t* error = wasm_trap_new(store, &name, true);
 
   wasm_name_delete(&name);
 
@@ -740,7 +748,7 @@ static wasm_trap_t* wasm_table_oob(wasm_store_t* store) {
   wasm_name_t name;
   wasm_name_new_from_string(&name, "out of bounds table access");
 
-  wasm_trap_t* error = wasm_trap_new(store, &name);
+  wasm_trap_t* error = wasm_trap_new(store, &name, false);
 
   wasm_name_delete(&name);
 


### PR DESCRIPTION
This patch illustrates what safe interfaces for `wasm_func_call`,
`wasm_global_set`, `wasm_instance_new`, `wasm_table_new`, `wasm_table_grow`,
`wasm_global_new`, `wasm_table_get`, `wasm_table_set` might look like.

This includes 10 new checks, including array length checking and type
checking. All the checks added are done in terms of existing API functions,
so this represents no major new burden on implementations.

This is a work in progress. More safety checks are possible beyond this.

This patch doesn't include checking for references crossing store boundaries.
It's a topic worth discussing, but I've omitted it in order to focus the
discussion around this patch.

Many of the details here will likely change as we iterate on this patch,
including the way errors are represented, naming conventions, coding style,
documentation conventions, or the way unchecked interfaces are exposed.

Wasm validation errors are of course distinct from runtime errors in the
wasm spec, and it's desirable to let API users distinguish between the two.
To keep things simple for now, I've just added a distinct string in the
trap message that users could test for. This can also be changed.

The checking could be more efficient. In particular, all allocations could
be avoided. I haven't done that yet, in order to demonstrate that
everything here is covered by existing API predicates.

This patch also converts `wasm_table_set`'s way of reporting out-of-bounds
errors from a bool to an error reported through wasm_trap_t. This more
closely reflects the actual wasm `table.set` semantics. Also, it allows
implementations to provide a more informative error message.