### PR TITLE
Use vectors for calls and imports

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -35,27 +35,27 @@ void wasm_val_print(wasm_val_t val) {
 
 // A function to be called from Wasm code.
 own wasm_trap_t* print_callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
-  wasm_val_print(args[0]);
+  wasm_val_print(args->data[0]);
   printf("\n");
 
-  wasm_val_copy(&results[0], &args[0]);
+  wasm_val_copy(&results->data[0], &args->data[0]);
   return NULL;
 }
 
 
 // A function closure.
 own wasm_trap_t* closure_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   int i = *(int*)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
 
-  results[0].kind = WASM_I32;
-  results[0].of.i32 = (int32_t)i;
+  results->data[0].kind = WASM_I32;
+  results->data[0].of.i32 = (int32_t)i;
   return NULL;
 }
 
@@ -108,11 +108,12 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
+  wasm_extern_t* externs[] = {
     wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
   };
+  wasm_extern_vec_t imports = { 2, externs };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -146,7 +147,9 @@ int main(int argc, const char* argv[]) {
   args[1].kind = WASM_I32;
   args[1].of.i32 = 4;
   wasm_val_t results[1];
-  if (wasm_func_call(run_func, args, results)) {
+  wasm_val_vec_t args_ = {2, args};
+  wasm_val_vec_t results_ = {1, results};
+  if (wasm_func_call(run_func, &args_, &results_)) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/callback.c
+++ b/example/callback.c
@@ -111,7 +111,7 @@ int main(int argc, const char* argv[]) {
   wasm_extern_t* externs[] = {
     wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
   };
-  wasm_extern_vec_t imports = { 2, externs };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -141,15 +141,11 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_t args[2];
-  args[0].kind = WASM_I32;
-  args[0].of.i32 = 3;
-  args[1].kind = WASM_I32;
-  args[1].of.i32 = 4;
-  wasm_val_t results[1];
-  wasm_val_vec_t args_ = {2, args};
-  wasm_val_vec_t results_ = {1, results};
-  if (wasm_func_call(run_func, &args_, &results_)) {
+  wasm_val_t as[2] = { WASM_I32_VAL(3), WASM_I32_VAL(4) };
+  wasm_val_t rs[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(as);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(rs);
+  if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;
   }
@@ -158,7 +154,7 @@ int main(int argc, const char* argv[]) {
 
   // Print result.
   printf("Printing result...\n");
-  printf("> %u\n", results[0].of.i32);
+  printf("> %u\n", rs[0].of.i32);
 
   // Shut down.
   printf("Shutting down...\n");

--- a/example/callback.cc
+++ b/example/callback.cc
@@ -103,8 +103,8 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(
-    move(print_func), move(closure_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(
+    print_func.get(), closure_func.get());
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/callback.cc
+++ b/example/callback.cc
@@ -35,7 +35,7 @@ auto operator<<(std::ostream& out, const wasm::Val& val) -> std::ostream& {
 
 // A function to be called from Wasm code.
 auto print_callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl << "> " << args[0] << std::endl;
   results[0] = args[0].copy();
@@ -45,7 +45,7 @@ auto print_callback(
 
 // A function closure.
 auto closure_callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
+  void* env, const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   auto i = *reinterpret_cast<int*>(env);
   std::cout << "Calling back closure..." << std::endl;
@@ -103,7 +103,8 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {print_func.get(), closure_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(
+    move(print_func), move(closure_func));
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -121,8 +122,8 @@ void run() {
 
   // Call.
   std::cout << "Calling export..." << std::endl;
-  wasm::Val args[] = {wasm::Val::i32(3), wasm::Val::i32(4)};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::i32(3), wasm::Val::i32(4));
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (run_func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -50,8 +50,9 @@ void run_in_store(wasm_store_t* store) {
   printf("Instantiating modules...\n");
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) printf("%d\n", i);
+    wasm_extern_vec_t imports = {0, NULL};
     own wasm_instance_t* instance =
-      wasm_instance_new(store, module, NULL, NULL);
+      wasm_instance_new(store, module, &imports, NULL);
     if (!instance) {
       printf("> Error instantiating module %d!\n", i);
       exit(1);

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -50,7 +50,7 @@ void run_in_store(wasm_store_t* store) {
   printf("Instantiating modules...\n");
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) printf("%d\n", i);
-    wasm_extern_vec_t imports = {0, NULL};
+    wasm_extern_vec_t imports = WASM_EMPTY_VEC;
     own wasm_instance_t* instance =
       wasm_instance_new(store, module, &imports, NULL);
     if (!instance) {

--- a/example/finalize.cc
+++ b/example/finalize.cc
@@ -46,7 +46,7 @@ void run_in_store(wasm::Store* store) {
   std::cout << "Instantiating modules..." << std::endl;
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) std::cout << i << std::endl;
-    auto imports = wasm::ownvec<wasm::Extern>::make();
+    auto imports = wasm::vec<wasm::Extern*>::make();
     auto instance = wasm::Instance::make(store, module.get(), imports);
     if (!instance) {
       std::cout << "> Error instantiating module " << i << "!" << std::endl;

--- a/example/finalize.cc
+++ b/example/finalize.cc
@@ -46,7 +46,8 @@ void run_in_store(wasm::Store* store) {
   std::cout << "Instantiating modules..." << std::endl;
   for (int i = 0; i <= iterations; ++i) {
     if (i % (iterations / 10) == 0) std::cout << i << std::endl;
-    auto instance = wasm::Instance::make(store, module.get(), nullptr);
+    auto imports = wasm::ownvec<wasm::Extern>::make();
+    auto instance = wasm::Instance::make(store, module.get(), imports);
     if (!instance) {
       std::cout << "> Error instantiating module " << i << "!" << std::endl;
       exit(1);

--- a/example/global.c
+++ b/example/global.c
@@ -39,9 +39,11 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 
 #define check_call(func, type, expected) \
   { \
-    wasm_val_t results[1]; \
-    wasm_func_call(func, NULL, results); \
-    check(results[0], type, expected); \
+    wasm_val_t vs[1]; \
+    wasm_val_vec_t args = {0, NULL}; \
+    wasm_val_vec_t results = {1, vs}; \
+    wasm_func_call(func, &args, &results); \
+    check(vs[0], type, expected); \
   }
 
 
@@ -110,14 +112,15 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
+  wasm_extern_t* externs[] = {
     wasm_global_as_extern(const_f32_import),
     wasm_global_as_extern(const_i64_import),
     wasm_global_as_extern(var_f32_import),
     wasm_global_as_extern(var_i64_import)
   };
+  wasm_extern_vec_t imports = {4, externs};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -195,14 +198,19 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 38);
 
   // Modify variables through calls and check again.
-  wasm_val_t args73[] = { {.kind = WASM_F32, .of = {.f32 = 73}} };
-  wasm_func_call(set_var_f32_import, args73, NULL);
-  wasm_val_t args74[] = { {.kind = WASM_I64, .of = {.i64 = 74}} };
-  wasm_func_call(set_var_i64_import, args74, NULL);
-  wasm_val_t args77[] = { {.kind = WASM_F32, .of = {.f32 = 77}} };
-  wasm_func_call(set_var_f32_export, args77, NULL);
-  wasm_val_t args78[] = { {.kind = WASM_I64, .of = {.i64 = 78}} };
-  wasm_func_call(set_var_i64_export, args78, NULL);
+  wasm_val_vec_t res = {0, NULL};
+  wasm_val_t vs73[] = { {.kind = WASM_F32, .of = {.f32 = 73}} };
+  wasm_val_vec_t args73 = {1, vs73};
+  wasm_func_call(set_var_f32_import, &args73, &res);
+  wasm_val_t vs74[] = { {.kind = WASM_I64, .of = {.i64 = 74}} };
+  wasm_val_vec_t args74 = {1, vs74};
+  wasm_func_call(set_var_i64_import, &args74, &res);
+  wasm_val_t vs77[] = { {.kind = WASM_F32, .of = {.f32 = 77}} };
+  wasm_val_vec_t args77 = {1, vs77};
+  wasm_func_call(set_var_f32_export, &args77, &res);
+  wasm_val_t vs78[] = { {.kind = WASM_I64, .of = {.i64 = 78}} };
+  wasm_val_vec_t args78 = {1, vs78};
+  wasm_func_call(set_var_i64_export, &args78, &res);
 
   check_global(var_f32_import, f32, 73);
   check_global(var_i64_import, i64, 74);

--- a/example/global.c
+++ b/example/global.c
@@ -40,8 +40,8 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 #define check_call(func, type, expected) \
   { \
     wasm_val_t vs[1]; \
-    wasm_val_vec_t args = {0, NULL}; \
-    wasm_val_vec_t results = {1, vs}; \
+    wasm_val_vec_t args = WASM_EMPTY_VEC; \
+    wasm_val_vec_t results = WASM_ARRAY_VEC(vs); \
     wasm_func_call(func, &args, &results); \
     check(vs[0], type, expected); \
   }
@@ -92,16 +92,16 @@ int main(int argc, const char* argv[]) {
   own wasm_globaltype_t* var_i64_type = wasm_globaltype_new(
     wasm_valtype_new(WASM_I64), WASM_VAR);
 
-  wasm_val_t val_f32_1 = {.kind = WASM_F32, .of = {.f32 = 1}};
+  wasm_val_t val_f32_1 = WASM_F32_VAL(1);
   own wasm_global_t* const_f32_import =
     wasm_global_new(store, const_f32_type, &val_f32_1);
-  wasm_val_t val_i64_2 = {.kind = WASM_I64, .of = {.i64 = 2}};
+  wasm_val_t val_i64_2 = WASM_I64_VAL(2);
   own wasm_global_t* const_i64_import =
     wasm_global_new(store, const_i64_type, &val_i64_2);
-  wasm_val_t val_f32_3 = {.kind = WASM_F32, .of = {.f32 = 3}};
+  wasm_val_t val_f32_3 = WASM_F32_VAL(3);
   own wasm_global_t* var_f32_import =
     wasm_global_new(store, var_f32_type, &val_f32_3);
-  wasm_val_t val_i64_4 = {.kind = WASM_I64, .of = {.i64 = 4}};
+  wasm_val_t val_i64_4 = WASM_I64_VAL(4);
   own wasm_global_t* var_i64_import =
     wasm_global_new(store, var_i64_type, &val_i64_4);
 
@@ -118,7 +118,7 @@ int main(int argc, const char* argv[]) {
     wasm_global_as_extern(var_f32_import),
     wasm_global_as_extern(var_i64_import)
   };
-  wasm_extern_vec_t imports = {4, externs};
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -178,13 +178,13 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 8);
 
   // Modify variables through API and check again.
-  wasm_val_t val33 = {.kind = WASM_F32, .of = {.f32 = 33}};
+  wasm_val_t val33 = WASM_F32_VAL(33);
   wasm_global_set(var_f32_import, &val33);
-  wasm_val_t val34 = {.kind = WASM_I64, .of = {.i64 = 34}};
+  wasm_val_t val34 = WASM_I64_VAL(34);
   wasm_global_set(var_i64_import, &val34);
-  wasm_val_t val37 = {.kind = WASM_F32, .of = {.f32 = 37}};
+  wasm_val_t val37 = WASM_F32_VAL(37);
   wasm_global_set(var_f32_export, &val37);
-  wasm_val_t val38 = {.kind = WASM_I64, .of = {.i64 = 38}};
+  wasm_val_t val38 = WASM_I64_VAL(38);
   wasm_global_set(var_i64_export, &val38);
 
   check_global(var_f32_import, f32, 33);
@@ -198,18 +198,18 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 38);
 
   // Modify variables through calls and check again.
-  wasm_val_vec_t res = {0, NULL};
-  wasm_val_t vs73[] = { {.kind = WASM_F32, .of = {.f32 = 73}} };
-  wasm_val_vec_t args73 = {1, vs73};
+  wasm_val_vec_t res = WASM_EMPTY_VEC;
+  wasm_val_t vs73[] = { WASM_F32_VAL(73) };
+  wasm_val_vec_t args73 = WASM_ARRAY_VEC(vs73);
   wasm_func_call(set_var_f32_import, &args73, &res);
-  wasm_val_t vs74[] = { {.kind = WASM_I64, .of = {.i64 = 74}} };
-  wasm_val_vec_t args74 = {1, vs74};
+  wasm_val_t vs74[] = { WASM_I64_VAL(74) };
+  wasm_val_vec_t args74 = WASM_ARRAY_VEC(vs74);
   wasm_func_call(set_var_i64_import, &args74, &res);
-  wasm_val_t vs77[] = { {.kind = WASM_F32, .of = {.f32 = 77}} };
-  wasm_val_vec_t args77 = {1, vs77};
+  wasm_val_t vs77[] = { WASM_F32_VAL(77) };
+  wasm_val_vec_t args77 = WASM_ARRAY_VEC(vs77);
   wasm_func_call(set_var_f32_export, &args77, &res);
-  wasm_val_t vs78[] = { {.kind = WASM_I64, .of = {.i64 = 78}} };
-  wasm_val_vec_t args78 = {1, vs78};
+  wasm_val_t vs78[] = { WASM_I64_VAL(78) };
+  wasm_val_vec_t args78 = WASM_ARRAY_VEC(vs78);
   wasm_func_call(set_var_i64_export, &args78, &res);
 
   check_global(var_f32_import, f32, 73);

--- a/example/global.cc
+++ b/example/global.cc
@@ -97,9 +97,9 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(
-    const_f32_import->copy(), const_i64_import->copy(),
-    var_f32_import->copy(), var_i64_import->copy()
+  auto imports = wasm::vec<wasm::Extern*>::make(
+    const_f32_import.get(), const_i64_import.get(),
+    var_f32_import.get(), var_i64_import.get()
   );
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {

--- a/example/global.cc
+++ b/example/global.cc
@@ -32,8 +32,9 @@ void check(T actual, U expected) {
 }
 
 auto call(const wasm::Func* func) -> wasm::Val {
-  wasm::Val results[1];
-  if (func->call(nullptr, results)) {
+  auto args = wasm::vec<wasm::Val>::make();
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
+  if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }
@@ -41,8 +42,9 @@ auto call(const wasm::Func* func) -> wasm::Val {
 }
 
 void call(const wasm::Func* func, wasm::Val&& arg) {
-  wasm::Val args[1] = {std::move(arg)};
-  if (func->call(args)) {
+  auto args = wasm::vec<wasm::Val>::make(std::move(arg));
+  auto results = wasm::vec<wasm::Val>::make();
+  if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }
@@ -95,10 +97,10 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {
-    const_f32_import.get(), const_i64_import.get(),
-    var_f32_import.get(), var_i64_import.get()
-  };
+  auto imports = wasm::ownvec<wasm::Extern>::make(
+    const_f32_import->copy(), const_i64_import->copy(),
+    var_f32_import->copy(), var_i64_import->copy()
+  );
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/hello.c
+++ b/example/hello.c
@@ -62,7 +62,7 @@ int main(int argc, const char* argv[]) {
   // Instantiate.
   printf("Instantiating module...\n");
   wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
-  wasm_extern_vec_t imports = { 1, externs };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -91,8 +91,8 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_vec_t args = {0, NULL};
-  wasm_val_vec_t results = {0, NULL};
+  wasm_val_vec_t args = WASM_EMPTY_VEC;
+  wasm_val_vec_t results = WASM_EMPTY_VEC;
   if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;

--- a/example/hello.c
+++ b/example/hello.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
@@ -61,9 +61,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports = { 1, externs };
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -90,7 +91,9 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(run_func, NULL, NULL)) {
+  wasm_val_vec_t args = {0, NULL};
+  wasm_val_vec_t results = {0, NULL};
+  if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 auto hello_callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> Hello world!" << std::endl;
@@ -55,7 +55,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {hello_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(move(hello_func));
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -73,7 +73,9 @@ void run() {
 
   // Call.
   std::cout << "Calling export..." << std::endl;
-  if (run_func->call()) {
+  auto args = wasm::vec<wasm::Val>::make();
+  auto results = wasm::vec<wasm::Val>::make();
+  if (run_func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -55,7 +55,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(move(hello_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(hello_func.get());
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/hostref.c
+++ b/example/hostref.c
@@ -47,24 +47,22 @@ wasm_table_t* get_export_table(const wasm_extern_vec_t* exports, size_t i) {
 
 own wasm_ref_t* call_v_r(const wasm_func_t* func) {
   printf("call_v_r... "); fflush(stdout);
-  wasm_val_t r;
-  wasm_val_vec_t args = {0, NULL};
-  wasm_val_vec_t results = {1, &r};
+  wasm_val_t rs[] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_EMPTY_VEC;
+  wasm_val_vec_t results = WASM_ARRAY_VEC(rs);
   if (wasm_func_call(func, &args, &results)) {
     printf("> Error calling function!\n");
     exit(1);
   }
   printf("okay\n");
-  return r.of.ref;
+  return rs[0].of.ref;
 }
 
 void call_r_v(const wasm_func_t* func, wasm_ref_t* ref) {
   printf("call_r_v... "); fflush(stdout);
-  wasm_val_t vs[1];
-  vs[0].kind = WASM_ANYREF;
-  vs[0].of.ref = ref;
-  wasm_val_vec_t args = {1, vs};
-  wasm_val_vec_t results = {0, NULL};
+  wasm_val_t vs[1] = { WASM_REF_VAL(ref) };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_EMPTY_VEC;
   if (wasm_func_call(func, &args, &results)) {
     printf("> Error calling function!\n");
     exit(1);
@@ -74,29 +72,23 @@ void call_r_v(const wasm_func_t* func, wasm_ref_t* ref) {
 
 own wasm_ref_t* call_r_r(const wasm_func_t* func, wasm_ref_t* ref) {
   printf("call_r_r... "); fflush(stdout);
-  wasm_val_t vs[1];
-  vs[0].kind = WASM_ANYREF;
-  vs[0].of.ref = ref;
-  wasm_val_t r;
-  wasm_val_vec_t args = {1, vs};
-  wasm_val_vec_t results = {1, &r};
+  wasm_val_t vs[1] = { WASM_REF_VAL(ref) };
+  wasm_val_t rs[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(rs);
   if (wasm_func_call(func, &args, &results)) {
     printf("> Error calling function!\n");
     exit(1);
   }
   printf("okay\n");
-  return r.of.ref;
+  return rs[0].of.ref;
 }
 
 void call_ir_v(const wasm_func_t* func, int32_t i, wasm_ref_t* ref) {
   printf("call_ir_v... "); fflush(stdout);
-  wasm_val_t vs[2];
-  vs[0].kind = WASM_I32;
-  vs[0].of.i32 = i;
-  vs[1].kind = WASM_ANYREF;
-  vs[1].of.ref = ref;
-  wasm_val_vec_t args = {2, vs};
-  wasm_val_vec_t results = {0, NULL};
+  wasm_val_t vs[2] = { WASM_I32_VAL(i), WASM_REF_VAL(ref) };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_EMPTY_VEC;
   if (wasm_func_call(func, &args, &results)) {
     printf("> Error calling function!\n");
     exit(1);
@@ -106,18 +98,16 @@ void call_ir_v(const wasm_func_t* func, int32_t i, wasm_ref_t* ref) {
 
 own wasm_ref_t* call_i_r(const wasm_func_t* func, int32_t i) {
   printf("call_i_r... "); fflush(stdout);
-  wasm_val_t vs[1];
-  vs[0].kind = WASM_I32;
-  vs[0].of.i32 = i;
-  wasm_val_t r;
-  wasm_val_vec_t args = {1, vs};
-  wasm_val_vec_t results = {1, &r};
+  wasm_val_t vs[1] = { WASM_I32_VAL(i) };
+  wasm_val_t rs[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(rs);
   if (wasm_func_call(func, &args, &results)) {
     printf("> Error calling function!\n");
     exit(1);
   }
   printf("okay\n");
-  return r.of.ref;
+  return rs[0].of.ref;
 }
 
 void check(own wasm_ref_t* actual, const wasm_ref_t* expected) {
@@ -178,7 +168,7 @@ int main(int argc, const char* argv[]) {
   // Instantiate.
   printf("Instantiating module...\n");
   wasm_extern_t* externs[] = { wasm_func_as_extern(callback_func) };
-  wasm_extern_vec_t imports = {1, externs};
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {

--- a/example/hostref.cc
+++ b/example/hostref.cc
@@ -151,7 +151,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(callback_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(callback_func.get());
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/hostref.cc
+++ b/example/hostref.cc
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 auto callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> " << (args[0].ref() ? args[0].ref()->get_host_info() : nullptr) << std::endl;
@@ -45,8 +45,9 @@ auto get_export_table(wasm::ownvec<wasm::Extern>& exports, size_t i) -> wasm::Ta
 
 void call_r_v(const wasm::Func* func, const wasm::Ref* ref) {
   std::cout << "call_r_v... " << std::flush;
-  wasm::Val args[1] = {wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
-  if (func->call(args, nullptr)) {
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>()));
+  auto results = wasm::vec<wasm::Val>::make();
+  if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }
@@ -55,8 +56,9 @@ void call_r_v(const wasm::Func* func, const wasm::Ref* ref) {
 
 auto call_v_r(const wasm::Func* func) -> wasm::own<wasm::Ref> {
   std::cout << "call_v_r... " << std::flush;
-  wasm::Val results[1];
-  if (func->call(nullptr, results)) {
+  auto args = wasm::vec<wasm::Val>::make();
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
+  if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }
@@ -66,8 +68,8 @@ auto call_v_r(const wasm::Func* func) -> wasm::own<wasm::Ref> {
 
 auto call_r_r(const wasm::Func* func, const wasm::Ref* ref) -> wasm::own<wasm::Ref> {
   std::cout << "call_r_r... " << std::flush;
-  wasm::Val args[1] = {wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>()));
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
@@ -78,8 +80,10 @@ auto call_r_r(const wasm::Func* func, const wasm::Ref* ref) -> wasm::own<wasm::R
 
 void call_ir_v(const wasm::Func* func, int32_t i, const wasm::Ref* ref) {
   std::cout << "call_ir_v... " << std::flush;
-  wasm::Val args[2] = {wasm::Val::i32(i), wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>())};
-  if (func->call(args, nullptr)) {
+  auto args = wasm::vec<wasm::Val>::make(
+    wasm::Val::i32(i), wasm::Val::ref(ref ? ref->copy() : wasm::own<wasm::Ref>()));
+  auto results = wasm::vec<wasm::Val>::make();
+  if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }
@@ -88,8 +92,8 @@ void call_ir_v(const wasm::Func* func, int32_t i, const wasm::Ref* ref) {
 
 auto call_i_r(const wasm::Func* func, int32_t i) -> wasm::own<wasm::Ref> {
   std::cout << "call_i_r... " << std::flush;
-  wasm::Val args[1] = {wasm::Val::i32(i)};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::i32(i));
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
@@ -147,7 +151,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {callback_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(callback_func));
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/memory.c
+++ b/example/memory.c
@@ -32,21 +32,23 @@ void check(bool success) {
   }
 }
 
-void check_call(wasm_func_t* func, wasm_val_t args[], int32_t expected) {
-  wasm_val_t results[1];
-  if (wasm_func_call(func, args, results) || results[0].of.i32 != expected) {
+void check_call(wasm_func_t* func, int i, wasm_val_t args[], int32_t expected) {
+  wasm_val_t r;
+  wasm_val_vec_t args_ = {i, args};
+  wasm_val_vec_t results = {1, &r};
+  if (wasm_func_call(func, &args_, &results) || r.of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
 void check_call0(wasm_func_t* func, int32_t expected) {
-  check_call(func, NULL, expected);
+  check_call(func, 0, NULL, expected);
 }
 
 void check_call1(wasm_func_t* func, int32_t arg, int32_t expected) {
   wasm_val_t args[] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
-  check_call(func, args, expected);
+  check_call(func, 1, args, expected);
 }
 
 void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
@@ -54,11 +56,13 @@ void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  check_call(func, args, expected);
+  check_call(func, 2, args, expected);
 }
 
-void check_ok(wasm_func_t* func, wasm_val_t args[]) {
-  if (wasm_func_call(func, args, NULL)) {
+void check_ok(wasm_func_t* func, int i, wasm_val_t args[]) {
+  wasm_val_vec_t args_ = {i, args};
+  wasm_val_vec_t results = {0, NULL};
+  if (wasm_func_call(func, &args_, &results)) {
     printf("> Error on result, expected empty\n");
     exit(1);
   }
@@ -69,12 +73,14 @@ void check_ok2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  check_ok(func, args);
+  check_ok(func, 2, args);
 }
 
-void check_trap(wasm_func_t* func, wasm_val_t args[]) {
-  wasm_val_t results[1];
-  own wasm_trap_t* trap = wasm_func_call(func, args, results);
+void check_trap(wasm_func_t* func, int i, wasm_val_t args[]) {
+  wasm_val_t r;
+  wasm_val_vec_t args_ = {i, args};
+  wasm_val_vec_t results = {1, &r};
+  own wasm_trap_t* trap = wasm_func_call(func, &args_, &results);
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);
@@ -84,7 +90,7 @@ void check_trap(wasm_func_t* func, wasm_val_t args[]) {
 
 void check_trap1(wasm_func_t* func, int32_t arg) {
   wasm_val_t args[1] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
-  check_trap(func, args);
+  check_trap(func, 1, args);
 }
 
 void check_trap2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
@@ -92,7 +98,7 @@ void check_trap2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  check_trap(func, args);
+  check_trap(func, 2, args);
 }
 
 
@@ -132,7 +138,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, NULL);
+  wasm_extern_vec_t imports = {0, NULL};
+  own wasm_instance_t* instance = wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/memory.c
+++ b/example/memory.c
@@ -33,7 +33,7 @@ void check(bool success) {
 }
 
 void check_call(wasm_func_t* func, int i, wasm_val_t args[], int32_t expected) {
-  wasm_val_t r;
+  wasm_val_t r = WASM_INIT_VAL;
   wasm_val_vec_t args_ = {i, args};
   wasm_val_vec_t results = {1, &r};
   if (wasm_func_call(func, &args_, &results) || r.of.i32 != expected) {
@@ -47,15 +47,12 @@ void check_call0(wasm_func_t* func, int32_t expected) {
 }
 
 void check_call1(wasm_func_t* func, int32_t arg, int32_t expected) {
-  wasm_val_t args[] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
+  wasm_val_t args[] = { WASM_I32_VAL(arg) };
   check_call(func, 1, args, expected);
 }
 
 void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
   check_call(func, 2, args, expected);
 }
 
@@ -69,15 +66,12 @@ void check_ok(wasm_func_t* func, int i, wasm_val_t args[]) {
 }
 
 void check_ok2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
   check_ok(func, 2, args);
 }
 
 void check_trap(wasm_func_t* func, int i, wasm_val_t args[]) {
-  wasm_val_t r;
+  wasm_val_t r = WASM_INIT_VAL;
   wasm_val_vec_t args_ = {i, args};
   wasm_val_vec_t results = {1, &r};
   own wasm_trap_t* trap = wasm_func_call(func, &args_, &results);
@@ -89,15 +83,12 @@ void check_trap(wasm_func_t* func, int i, wasm_val_t args[]) {
 }
 
 void check_trap1(wasm_func_t* func, int32_t arg) {
-  wasm_val_t args[1] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
+  wasm_val_t args[] = { WASM_I32_VAL(arg) };
   check_trap(func, 1, args);
 }
 
 void check_trap2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
   check_trap(func, 2, args);
 }
 
@@ -138,8 +129,9 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports = {0, NULL};
-  own wasm_instance_t* instance = wasm_instance_new(store, module, &imports, NULL);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  own wasm_instance_t* instance =
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/memory.cc
+++ b/example/memory.cc
@@ -33,8 +33,9 @@ void check(T actual, U expected) {
 
 template<class... Args>
 void check_ok(const wasm::Func* func, Args... xs) {
-  wasm::Val args[] = {wasm::Val::i32(xs)...};
-  if (func->call(args)) {
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::i32(xs)...);
+  auto results = wasm::vec<wasm::Val>::make();
+  if (func->call(args, results)) {
     std::cout << "> Error on result, expected return" << std::endl;
     exit(1);
   }
@@ -42,8 +43,9 @@ void check_ok(const wasm::Func* func, Args... xs) {
 
 template<class... Args>
 void check_trap(const wasm::Func* func, Args... xs) {
-  wasm::Val args[] = {wasm::Val::i32(xs)...};
-  if (! func->call(args)) {
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::i32(xs)...);
+  auto results = wasm::vec<wasm::Val>::make();
+  if (! func->call(args, results)) {
     std::cout << "> Error on result, expected trap" << std::endl;
     exit(1);
   }
@@ -51,8 +53,8 @@ void check_trap(const wasm::Func* func, Args... xs) {
 
 template<class... Args>
 auto call(const wasm::Func* func, Args... xs) -> int32_t {
-  wasm::Val args[] = {wasm::Val::i32(xs)...};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(wasm::Val::i32(xs)...);
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (func->call(args, results)) {
     std::cout << "> Error on result, expected return" << std::endl;
     exit(1);
@@ -92,7 +94,8 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto instance = wasm::Instance::make(store, module.get(), nullptr);
+  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
     exit(1);

--- a/example/memory.cc
+++ b/example/memory.cc
@@ -94,7 +94,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto imports = wasm::vec<wasm::Extern*>::make();
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/multi.c
+++ b/example/multi.c
@@ -90,8 +90,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_t* externs[] = {wasm_func_as_extern(callback_func)};
-  wasm_extern_vec_t imports = {1, externs};
+  wasm_extern_t* externs[] = { wasm_func_as_extern(callback_func) };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -120,18 +120,14 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_t vals[4];
-  vals[0].kind = WASM_I32;
-  vals[0].of.i32 = 1;
-  vals[1].kind = WASM_I64;
-  vals[1].of.i64 = 2;
-  vals[2].kind = WASM_I64;
-  vals[2].of.i64 = 3;
-  vals[3].kind = WASM_I32;
-  vals[3].of.i32 = 4;
-  wasm_val_t res[4];
-  wasm_val_vec_t args = {4, vals};
-  wasm_val_vec_t results = {4, res};
+  wasm_val_t vals[4] = {
+    WASM_I32_VAL(1), WASM_I32_VAL(2), WASM_I32_VAL(3), WASM_I32_VAL(4)
+  };
+  wasm_val_t res[4] = {
+    WASM_INIT_VAL, WASM_INIT_VAL, WASM_INIT_VAL, WASM_INIT_VAL
+  };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vals);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(res);
   if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;

--- a/example/multi.c
+++ b/example/multi.c
@@ -9,31 +9,32 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
   printf("> %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu32"\n",
-    args[0].of.i32, args[1].of.i64, args[2].of.i64, args[3].of.i32);
+    args->data[0].of.i32, args->data[1].of.i64,
+    args->data[2].of.i64, args->data[3].of.i32);
   printf("\n");
 
-  wasm_val_copy(&results[0], &args[3]);
-  wasm_val_copy(&results[1], &args[1]);
-  wasm_val_copy(&results[2], &args[2]);
-  wasm_val_copy(&results[3], &args[0]);
+  wasm_val_copy(&results->data[0], &args->data[3]);
+  wasm_val_copy(&results->data[1], &args->data[1]);
+  wasm_val_copy(&results->data[2], &args->data[2]);
+  wasm_val_copy(&results->data[3], &args->data[0]);
   return NULL;
 }
 
 
 // A function closure.
 own wasm_trap_t* closure_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   int i = *(int*)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
 
-  results[0].kind = WASM_I32;
-  results[0].of.i32 = (int32_t)i;
+  results->data[0].kind = WASM_I32;
+  results->data[0].of.i32 = (int32_t)i;
   return NULL;
 }
 
@@ -89,9 +90,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {wasm_func_as_extern(callback_func)};
+  wasm_extern_t* externs[] = {wasm_func_as_extern(callback_func)};
+  wasm_extern_vec_t imports = {1, externs};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -118,17 +120,19 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_t args[4];
-  args[0].kind = WASM_I32;
-  args[0].of.i32 = 1;
-  args[1].kind = WASM_I64;
-  args[1].of.i64 = 2;
-  args[2].kind = WASM_I64;
-  args[2].of.i64 = 3;
-  args[3].kind = WASM_I32;
-  args[3].of.i32 = 4;
-  wasm_val_t results[4];
-  if (wasm_func_call(run_func, args, results)) {
+  wasm_val_t vals[4];
+  vals[0].kind = WASM_I32;
+  vals[0].of.i32 = 1;
+  vals[1].kind = WASM_I64;
+  vals[1].of.i64 = 2;
+  vals[2].kind = WASM_I64;
+  vals[2].of.i64 = 3;
+  vals[3].kind = WASM_I32;
+  vals[3].of.i32 = 4;
+  wasm_val_t res[4];
+  wasm_val_vec_t args = {4, vals};
+  wasm_val_vec_t results = {4, res};
+  if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;
   }
@@ -138,13 +142,12 @@ int main(int argc, const char* argv[]) {
   // Print result.
   printf("Printing result...\n");
   printf("> %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu32"\n",
-    results[0].of.i32, results[1].of.i64,
-    results[2].of.i64, results[3].of.i32);
+    res[0].of.i32, res[1].of.i64, res[2].of.i64, res[3].of.i32);
 
-  assert(results[0].of.i32 == 4);
-  assert(results[1].of.i64 == 3);
-  assert(results[2].of.i64 == 2);
-  assert(results[3].of.i32 == 1);
+  assert(res[0].of.i32 == 4);
+  assert(res[1].of.i64 == 3);
+  assert(res[2].of.i64 == 2);
+  assert(res[3].of.i32 == 1);
 
   // Shut down.
   printf("Shutting down...\n");

--- a/example/multi.cc
+++ b/example/multi.cc
@@ -66,7 +66,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(callback_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(callback_func.get());
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/multi.cc
+++ b/example/multi.cc
@@ -8,7 +8,7 @@
 
 // A function to be called from Wasm code.
 auto callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> " << args[0].i32();
@@ -66,7 +66,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {callback_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(callback_func));
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -84,10 +84,10 @@ void run() {
 
   // Call.
   std::cout << "Calling export..." << std::endl;
-  wasm::Val args[] = {
+  auto args = wasm::vec<wasm::Val>::make(
     wasm::Val::i32(1), wasm::Val::i64(2), wasm::Val::i64(3), wasm::Val::i32(4)
-  };
-  wasm::Val results[4];
+  );
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(4);
   if (wasm::own<wasm::Trap> trap = run_func->call(args, results)) {
     std::cout << "> Error calling function! " << trap->message().get() << std::endl;
     exit(1);

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -118,7 +118,9 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, NULL);
+  wasm_extern_vec_t imports = {0, NULL};
+  own wasm_instance_t* instance =
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -118,7 +118,7 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports = {0, NULL};
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {

--- a/example/reflect.cc
+++ b/example/reflect.cc
@@ -101,7 +101,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto imports = wasm::vec<wasm::Extern*>::make();
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/reflect.cc
+++ b/example/reflect.cc
@@ -101,7 +101,8 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto instance = wasm::Instance::make(store, module.get(), nullptr);
+  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
     exit(1);

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -8,7 +8,9 @@
 #define own
 
 // A function to be called from Wasm code.
-own wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
+own wasm_trap_t* hello_callback(
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
+) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -76,9 +78,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating deserialized module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports = {1, externs};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, deserialized, imports, NULL);
+    wasm_instance_new(store, deserialized, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -105,7 +108,8 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(run_func, NULL, NULL)) {
+  wasm_val_vec_t empty = {0, NULL};
+  if (wasm_func_call(run_func, &empty, &empty)) {
     printf("> Error calling function!\n");
     return 1;
   }

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -79,7 +79,7 @@ int main(int argc, const char* argv[]) {
   // Instantiate.
   printf("Instantiating deserialized module...\n");
   wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
-  wasm_extern_vec_t imports = {1, externs};
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, deserialized, &imports, NULL);
   if (!instance) {
@@ -108,7 +108,7 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_vec_t empty = {0, NULL};
+  wasm_val_vec_t empty = WASM_EMPTY_VEC;
   if (wasm_func_call(run_func, &empty, &empty)) {
     printf("> Error calling function!\n");
     return 1;

--- a/example/serialize.cc
+++ b/example/serialize.cc
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 auto hello_callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   std::cout << "> Hello world!" << std::endl;
@@ -67,7 +67,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating deserialized module..." << std::endl;
-  wasm::Extern* imports[] = {hello_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(hello_func));
   auto instance = wasm::Instance::make(store, deserialized.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -85,7 +85,9 @@ void run() {
 
   // Call.
   std::cout << "Calling export..." << std::endl;
-  if (run_func->call()) {
+  auto args = wasm::vec<wasm::Val>::make();
+  auto results = wasm::vec<wasm::Val>::make();
+  if (run_func->call(args, results)) {
     std::cout << "> Error calling function!" << std::endl;
     exit(1);
   }

--- a/example/serialize.cc
+++ b/example/serialize.cc
@@ -67,7 +67,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating deserialized module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(std::move(hello_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(hello_func.get());
   auto instance = wasm::Instance::make(store, deserialized.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/start.c
+++ b/example/start.c
@@ -54,9 +54,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
+  wasm_extern_vec_t imports = {0, NULL};
   own wasm_trap_t* trap = NULL;
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, NULL, &trap);
+    wasm_instance_new(store, module, &imports, &trap);
   if (instance || !trap) {
     printf("> Error instantiating module, expected trap!\n");
     return 1;

--- a/example/start.c
+++ b/example/start.c
@@ -54,7 +54,7 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports = {0, NULL};
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
   own wasm_trap_t* trap = NULL;
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, &trap);

--- a/example/start.cc
+++ b/example/start.cc
@@ -47,7 +47,8 @@ void run() {
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
   wasm::own<wasm::Trap> trap;
-  auto instance = wasm::Instance::make(store, module.get(), nullptr, &trap);
+  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto instance = wasm::Instance::make(store, module.get(), imports, &trap);
   if (instance || !trap) {
     std::cout << "> Error instantiating module, expected trap!" << std::endl;
     exit(1);

--- a/example/start.cc
+++ b/example/start.cc
@@ -47,7 +47,7 @@ void run() {
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
   wasm::own<wasm::Trap> trap;
-  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto imports = wasm::vec<wasm::Extern*>::make();
   auto instance = wasm::Instance::make(store, module.get(), imports, &trap);
   if (instance || !trap) {
     std::cout << "> Error instantiating module, expected trap!" << std::endl;

--- a/example/table.c
+++ b/example/table.c
@@ -49,27 +49,21 @@ void check_table(wasm_table_t* table, int32_t i, bool expect_set) {
 }
 
 void check_call(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t vs[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
-  wasm_val_t r;
-  wasm_val_vec_t args = {2, vs};
-  wasm_val_vec_t results = {1, &r};
-  if (wasm_func_call(func, &args, &results) || r.of.i32 != expected) {
+  wasm_val_t vs[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_t r[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(r);
+  if (wasm_func_call(func, &args, &results) || r[0].of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
 void check_trap(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t vs[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
-  wasm_val_t r;
-  wasm_val_vec_t args = {2, vs};
-  wasm_val_vec_t results = {1, &r};
+  wasm_val_t vs[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_t r[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(r);
   own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
   if (! trap) {
     printf("> Error on result, expected trap\n");
@@ -115,7 +109,7 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports = {0, NULL};
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {

--- a/example/table.c
+++ b/example/table.c
@@ -9,11 +9,11 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* neg_callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
-  results[0].kind = WASM_I32;
-  results[0].of.i32 = -args[0].of.i32;
+  results->data[0].kind = WASM_I32;
+  results->data[0].of.i32 = -args->data[0].of.i32;
   return NULL;
 }
 
@@ -49,23 +49,28 @@ void check_table(wasm_table_t* table, int32_t i, bool expect_set) {
 }
 
 void check_call(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t args[2] = {
+  wasm_val_t vs[2] = {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  wasm_val_t results[1];
-  if (wasm_func_call(func, args, results) || results[0].of.i32 != expected) {
+  wasm_val_t r;
+  wasm_val_vec_t args = {2, vs};
+  wasm_val_vec_t results = {1, &r};
+  if (wasm_func_call(func, &args, &results) || r.of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
 void check_trap(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
+  wasm_val_t vs[2] = {
     {.kind = WASM_I32, .of = {.i32 = arg1}},
     {.kind = WASM_I32, .of = {.i32 = arg2}}
   };
-  own wasm_trap_t* trap = wasm_func_call(func, args, NULL);
+  wasm_val_t r;
+  wasm_val_vec_t args = {2, vs};
+  wasm_val_vec_t results = {1, &r};
+  own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);
@@ -110,7 +115,9 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t* instance = wasm_instance_new(store, module, NULL, NULL);
+  wasm_extern_vec_t imports = {0, NULL};
+  own wasm_instance_t* instance =
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/example/table.cc
+++ b/example/table.cc
@@ -100,7 +100,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto imports = wasm::vec<wasm::Extern*>::make();
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/example/table.cc
+++ b/example/table.cc
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 auto neg_callback(
-  const wasm::Val args[], wasm::Val results[]
+  const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   results[0] = wasm::Val(-args[0].i32());
@@ -51,8 +51,8 @@ void check(bool success) {
 auto call(
   const wasm::Func* func, wasm::Val&& arg1, wasm::Val&& arg2
 ) -> wasm::Val {
-  wasm::Val args[2] = {std::move(arg1), std::move(arg2)};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(std::move(arg1), std::move(arg2));
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (func->call(args, results)) {
     std::cout << "> Error on result, expected return" << std::endl;
     exit(1);
@@ -61,8 +61,8 @@ auto call(
 }
 
 void check_trap(const wasm::Func* func, wasm::Val&& arg1, wasm::Val&& arg2) {
-  wasm::Val args[2] = {std::move(arg1), std::move(arg2)};
-  wasm::Val results[1];
+  auto args = wasm::vec<wasm::Val>::make(std::move(arg1), std::move(arg2));
+  auto results = wasm::vec<wasm::Val>::make_uninitialized(1);
   if (! func->call(args, results)) {
     std::cout << "> Error on result, expected trap" << std::endl;
     exit(1);
@@ -100,7 +100,8 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto instance = wasm::Instance::make(store, module.get(), nullptr);
+  auto imports = wasm::ownvec<wasm::Extern>::make();
+  auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
     exit(1);

--- a/example/threads.c
+++ b/example/threads.c
@@ -42,7 +42,7 @@ void* run(void* args_abs) {
     own wasm_func_t* func = wasm_func_new(store, func_type, callback);
     wasm_functype_delete(func_type);
 
-    wasm_val_t val = {.kind = WASM_I32, .of = {.i32 = (int32_t)args->id}};
+    wasm_val_t val = WASM_I32_VAL((int32_t)args->id);
     own wasm_globaltype_t* global_type =
       wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
     own wasm_global_t* global = wasm_global_new(store, global_type, &val);
@@ -52,7 +52,7 @@ void* run(void* args_abs) {
     wasm_extern_t* externs[] = {
       wasm_func_as_extern(func), wasm_global_as_extern(global),
     };
-    wasm_extern_vec_t imports = {2, externs};
+    wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
     own wasm_instance_t* instance =
       wasm_instance_new(store, module, &imports, NULL);
     if (!instance) {
@@ -79,7 +79,7 @@ void* run(void* args_abs) {
     wasm_instance_delete(instance);
 
     // Call.
-    wasm_val_vec_t empty = {0, NULL};
+    wasm_val_vec_t empty = WASM_EMPTY_VEC;
     if (wasm_func_call(run_func, &empty, &empty)) {
       printf("> Error calling function!\n");
       return NULL;

--- a/example/threads.cc
+++ b/example/threads.cc
@@ -10,7 +10,7 @@ const int N_REPS = 3;
 
 // A function to be called from Wasm code.
 auto callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
+  void* env, const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   assert(args[0].kind() == wasm::ValKind::I32);
   std::lock_guard<std::mutex> lock(*reinterpret_cast<std::mutex*>(env));
@@ -53,7 +53,8 @@ void run(
       store, global_type.get(), wasm::Val::i32(i));
 
     // Instantiate.
-    wasm::Extern* imports[] = {func.get(), global.get()};
+    auto imports = wasm::ownvec<wasm::Extern>::make(
+      std::move(func), std::move(global));
     auto instance = wasm::Instance::make(store, module.get(), imports);
     if (!instance) {
       std::lock_guard<std::mutex> lock(*mutex);
@@ -71,7 +72,8 @@ void run(
     auto run_func = exports[0]->func();
 
     // Call.
-    run_func->call();
+    auto empty = wasm::vec<wasm::Val>::make();
+    run_func->call(empty, empty);
   }
 }
 

--- a/example/threads.cc
+++ b/example/threads.cc
@@ -53,8 +53,7 @@ void run(
       store, global_type.get(), wasm::Val::i32(i));
 
     // Instantiate.
-    auto imports = wasm::ownvec<wasm::Extern>::make(
-      std::move(func), std::move(global));
+    auto imports = wasm::vec<wasm::Extern*>::make(func.get(), global.get());
     auto instance = wasm::Instance::make(store, module.get(), imports);
     if (!instance) {
       std::lock_guard<std::mutex> lock(*mutex);

--- a/example/trap.c
+++ b/example/trap.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* fail_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   own wasm_name_t message;
@@ -75,9 +75,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_t* externs[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_vec_t imports = {1, externs};
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -106,7 +107,9 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    own wasm_trap_t* trap = wasm_func_call(func, NULL, NULL);
+    wasm_val_vec_t args = {0, NULL};
+    wasm_val_vec_t results = {0, NULL};
+    own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
     if (!trap) {
       printf("> Error calling function, expected trap!\n");
       return 1;

--- a/example/trap.c
+++ b/example/trap.c
@@ -76,7 +76,7 @@ int main(int argc, const char* argv[]) {
   // Instantiate.
   printf("Instantiating module...\n");
   wasm_extern_t* externs[] = { wasm_func_as_extern(fail_func) };
-  wasm_extern_vec_t imports = {1, externs};
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -107,8 +107,8 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    wasm_val_vec_t args = {0, NULL};
-    wasm_val_vec_t results = {0, NULL};
+    wasm_val_vec_t args = WASM_EMPTY_VEC;
+    wasm_val_vec_t results = WASM_EMPTY_VEC;
     own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
     if (!trap) {
       printf("> Error calling function, expected trap!\n");

--- a/example/trap.cc
+++ b/example/trap.cc
@@ -8,7 +8,7 @@
 
 // A function to be called from Wasm code.
 auto fail_callback(
-  void* env, const wasm::Val args[], wasm::Val results[]
+  void* env, const wasm::vec<wasm::Val>& args, wasm::vec<wasm::Val>& results
 ) -> wasm::own<wasm::Trap> {
   std::cout << "Calling back..." << std::endl;
   auto store = reinterpret_cast<wasm::Store*>(env);
@@ -65,7 +65,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  wasm::Extern* imports[] = {fail_func.get()};
+  auto imports = wasm::ownvec<wasm::Extern>::make(move(fail_func));
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
@@ -85,7 +85,9 @@ void run() {
   // Call.
   for (size_t i = 0; i < 2; ++i) {
     std::cout << "Calling export " << i << "..." << std::endl;
-    auto trap = exports[i]->func()->call();
+    auto args = wasm::vec<wasm::Val>::make();
+    auto results = wasm::vec<wasm::Val>::make();
+    auto trap = exports[i]->func()->call(args, results);
     if (!trap) {
       std::cout << "> Error calling function, expected trap!" << std::endl;
       exit(1);

--- a/example/trap.cc
+++ b/example/trap.cc
@@ -65,7 +65,7 @@ void run() {
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::ownvec<wasm::Extern>::make(move(fail_func));
+  auto imports = wasm::vec<wasm::Extern*>::make(fail_func.get());
   auto instance = wasm::Instance::make(store, module.get(), imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -520,6 +520,12 @@ WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_exte
 ///////////////////////////////////////////////////////////////////////////////
 // Convenience
 
+// Vectors
+
+#define WASM_EMPTY_VEC {0, NULL}
+#define WASM_ARRAY_VEC(array) {sizeof(array)/sizeof(*(array)), array}
+
+
 // Value Type construction short-hands
 
 static inline own wasm_valtype_t* wasm_valtype_new_i32() {
@@ -691,6 +697,13 @@ static inline void* wasm_val_ptr(const wasm_val_t* val) {
   return (void*)(intptr_t)val->of.i64;
 #endif
 }
+
+#define WASM_I32_VAL(i) {.kind = WASM_I32, .of = {.i32 = i}}
+#define WASM_I64_VAL(i) {.kind = WASM_I64, .of = {.i64 = i}}
+#define WASM_F32_VAL(z) {.kind = WASM_F32, .of = {.f32 = z}}
+#define WASM_F64_VAL(z) {.kind = WASM_F64, .of = {.f64 = z}}
+#define WASM_REF_VAL(r) {.kind = WASM_ANYREF, .of = {.ref = r}}
+#define WASM_INIT_VAL {.kind = WASM_ANYREF, .of = {.ref = NULL}}
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -510,7 +510,7 @@ WASM_API_EXTERN const wasm_memory_t* wasm_extern_as_memory_const(const wasm_exte
 WASM_DECLARE_REF(instance)
 
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
-  wasm_store_t*, const wasm_module_t*, own wasm_extern_vec_t* imports,
+  wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t* imports,
   own wasm_trap_t**
 );
 

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -408,9 +408,9 @@ WASM_API_EXTERN own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const 
 WASM_DECLARE_REF(func)
 
 typedef own wasm_trap_t* (*wasm_func_callback_t)(
-  const wasm_val_t args[], wasm_val_t results[]);
+  const wasm_val_vec_t* args, own wasm_val_vec_t* results);
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
-  void* env, const wasm_val_t args[], wasm_val_t results[]);
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results);
 
 WASM_API_EXTERN own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
@@ -423,7 +423,7 @@ WASM_API_EXTERN size_t wasm_func_param_arity(const wasm_func_t*);
 WASM_API_EXTERN size_t wasm_func_result_arity(const wasm_func_t*);
 
 WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
-  const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
+  const wasm_func_t*, const wasm_val_vec_t* args, wasm_val_vec_t* results);
 
 
 // Global Instances
@@ -510,7 +510,7 @@ WASM_API_EXTERN const wasm_memory_t* wasm_extern_as_memory_const(const wasm_exte
 WASM_DECLARE_REF(instance)
 
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
-  wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const imports[],
+  wasm_store_t*, const wasm_module_t*, own wasm_extern_vec_t* imports,
   own wasm_trap_t**
 );
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -431,11 +431,11 @@ class Val {
 
 public:
   Val() : kind_(ValKind::ANYREF) { impl_.ref = nullptr; }
-  Val(int32_t i) : kind_(ValKind::I32) { impl_.i32 = i; }
-  Val(int64_t i) : kind_(ValKind::I64) { impl_.i64 = i; }
-  Val(float32_t z) : kind_(ValKind::F32) { impl_.f32 = z; }
-  Val(float64_t z) : kind_(ValKind::F64) { impl_.f64 = z; }
-  Val(own<Ref>&& r) : kind_(ValKind::ANYREF) { impl_.ref = r.release(); }
+  explicit Val(int32_t i) : kind_(ValKind::I32) { impl_.i32 = i; }
+  explicit Val(int64_t i) : kind_(ValKind::I64) { impl_.i64 = i; }
+  explicit Val(float32_t z) : kind_(ValKind::F32) { impl_.f32 = z; }
+  explicit Val(float64_t z) : kind_(ValKind::F64) { impl_.f64 = z; }
+  explicit Val(own<Ref>&& r) : kind_(ValKind::ANYREF) { impl_.ref = r.release(); }
 
   Val(Val&& that) : kind_(that.kind_), impl_(that.impl_) {
     if (is_ref()) that.impl_.ref = nullptr;
@@ -648,8 +648,8 @@ public:
   Func() = delete;
   ~Func();
 
-  using callback = auto (*)(const Val[], Val[]) -> own<Trap>;
-  using callback_with_env = auto (*)(void*, const Val[], Val[]) -> own<Trap>;
+  using callback = auto (*)(const vec<Val>&, vec<Val>&) -> own<Trap>;
+  using callback_with_env = auto (*)(void*, const vec<Val>&, vec<Val>&) -> own<Trap>;
 
   static auto make(Store*, const FuncType*, callback) -> own<Func>;
   static auto make(Store*, const FuncType*, callback_with_env,
@@ -660,7 +660,7 @@ public:
   auto param_arity() const -> size_t;
   auto result_arity() const -> size_t;
 
-  auto call(const Val[] = nullptr, Val[] = nullptr) const -> own<Trap>;
+  auto call(const vec<Val>&, vec<Val>&) const -> own<Trap>;
 };
 
 
@@ -731,7 +731,7 @@ public:
   ~Instance();
 
   static auto make(
-    Store*, const Module*, const Extern* const[], own<Trap>* = nullptr
+    Store*, const Module*, const ownvec<Extern>&, own<Trap>* = nullptr
   ) -> own<Instance>;
   auto copy() const -> own<Instance>;
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -731,7 +731,7 @@ public:
   ~Instance();
 
   static auto make(
-    Store*, const Module*, const ownvec<Extern>&, own<Trap>* = nullptr
+    Store*, const Module*, const vec<Extern*>&, own<Trap>* = nullptr
   ) -> own<Instance>;
   auto copy() const -> own<Instance>;
 

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -1687,7 +1687,7 @@ auto Func::result_arity() const -> size_t {
   return wasm_v8::func_type_result_arity(impl(this)->v8_object());
 }
 
-auto Func::call(const Val args[], Val results[]) const -> own<Trap> {
+auto Func::call(const vec<Val>& args, vec<Val>& results) const -> own<Trap> {
   auto func = impl(this);
   auto store = func->store();
   auto isolate = store->isolate();
@@ -1754,17 +1754,17 @@ void FuncData::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   assert(param_types.size() == info.Length());
 
   // TODO: cache params and result arrays per thread.
-  auto args = std::unique_ptr<Val[]>(new Val[param_types.size()]);
-  auto results = std::unique_ptr<Val[]>(new Val[result_types.size()]);
+  auto args = vec<Val>::make_uninitialized(param_types.size());
+  auto results = vec<Val>::make_uninitialized(result_types.size());
   for (size_t i = 0; i < param_types.size(); ++i) {
     args[i] = v8_to_val(store, info[i], param_types[i].get());
   }
 
   own<Trap> trap;
   if (self->kind == CALLBACK_WITH_ENV) {
-    trap = self->callback_with_env(self->env, args.get(), results.get());
+    trap = self->callback_with_env(self->env, args, results);
   } else {
-    trap = self->callback(args.get(), results.get());
+    trap = self->callback(args, results);
   }
 
   if (trap) {
@@ -2019,7 +2019,7 @@ auto Instance::copy() const -> own<Instance> {
 }
 
 auto Instance::make(
-  Store* store_abs, const Module* module_abs, const Extern* const imports[],
+  Store* store_abs, const Module* module_abs, const ownvec<Extern>& imports,
   own<Trap>* trap
 ) -> own<Instance> {
   auto store = impl(store_abs);
@@ -2058,7 +2058,7 @@ auto Instance::make(
     }
 
     ignore(module_obj->DefineOwnProperty(
-      context, name_str, extern_to_v8(imports[i])));
+      context, name_str, extern_to_v8(imports[i].get())));
   }
 
   v8::TryCatch handler(isolate);

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -229,6 +229,7 @@ DEFINE_VEC(Global, ownvec, GLOBAL)
 DEFINE_VEC(Table, ownvec, TABLE)
 DEFINE_VEC(Memory, ownvec, MEMORY)
 DEFINE_VEC(Extern, ownvec, EXTERN)
+DEFINE_VEC(Extern*, vec, EXTERN)
 DEFINE_VEC(Val, vec, VAL)
 
 #endif  // #ifdef WASM_API_DEBUG
@@ -2019,7 +2020,7 @@ auto Instance::copy() const -> own<Instance> {
 }
 
 auto Instance::make(
-  Store* store_abs, const Module* module_abs, const ownvec<Extern>& imports,
+  Store* store_abs, const Module* module_abs, const vec<Extern*>& imports,
   own<Trap>* trap
 ) -> own<Instance> {
   auto store = impl(store_abs);
@@ -2058,7 +2059,7 @@ auto Instance::make(
     }
 
     ignore(module_obj->DefineOwnProperty(
-      context, name_str, extern_to_v8(imports[i].get())));
+      context, name_str, extern_to_v8(imports[i])));
   }
 
   v8::TryCatch handler(isolate);


### PR DESCRIPTION
Return to using vectors for function call arguments and results, as well as module imports. This was simplified to a straight array interface in #48, but additional sanity checks have been requested.

Unlike #134, this avoids the use of struct-by-value in the C API and implements the API change consistently in both C and C++ API.