### PR TITLE
Add Wasmer as an implementor of Wasm C API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Currently, known implementations of this API are included in
 * V8 natively (both C and C++)
 * Wabt (only C?)
 * Wasmtime (only C?)
+* [Wasmer](https://github.com/wasmerio/wasmer/tree/master/lib/c-api) (only C, C++ coming soon)
 
 
 ### TODO


### PR DESCRIPTION
We recently added support for the Wasm-C-API in Wasmer.

We are working on adding more tests, but in general the API is pretty well covered:
https://github.com/wasmerio/wasmer/blob/master/lib/c-api/tests/CMakeLists.txt#L22-L30

:)