### PR TITLE
feat: `wasm_name_new_from_string*` owns `s`

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -105,13 +105,13 @@ typedef wasm_byte_vec_t wasm_name_t;
 #define wasm_name_delete wasm_byte_vec_delete
 
 static inline void wasm_name_new_from_string(
-  own wasm_name_t* out, const char* s
+  own wasm_name_t* out, own const char* s
 ) {
   wasm_name_new(out, strlen(s), s);
 }
 
 static inline void wasm_name_new_from_string_nt(
-  own wasm_name_t* out, const char* s
+  own wasm_name_t* out, own const char* s
 ) {
   wasm_name_new(out, strlen(s) + 1, s);
 }


### PR DESCRIPTION
`wasm_name_new` is an alias to `wasm_byte_vec_new`, which owns the
`ptr_or_none` argument, which is in this case `s`.

This patch adds the `own` market to `wasm_name_new_from_string` and
`wasm_name_new_from_string_nt`.