### PR TITLE
feat: Add `wasm_module_name` and `wasm_module_set_name`.

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -402,6 +402,9 @@ WASM_API_EXTERN own wasm_module_t* wasm_module_new(
 
 WASM_API_EXTERN bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* binary);
 
+WASM_API_EXTERN void wasm_module_name(const wasm_module_t*, own wasm_name_t* out);
+WASM_API_EXTERN bool wasm_module_set_name(wasm_module_t*, const wasm_name_t* name);
+
 WASM_API_EXTERN void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
 WASM_API_EXTERN void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -595,6 +595,9 @@ public:
   static auto make(Store*, const vec<byte_t>& binary) -> own<Module>;
   auto copy() const -> own<Module>;
 
+  auto name() const -> vec<byte_t>;
+  auto set_name(const vec<byte_t>&) -> bool;
+
   auto imports() const -> ownvec<ImportType>;
   auto exports() const -> ownvec<ExportType>;
 


### PR DESCRIPTION
This patch proposes 2 new functions to handle module's name:

* `wasm_module_name` that writes the module's name in a `wasm_name_t`
  if any,
* `wasm_module_set_name` that sets the module's name if possible.

`wasm_module_set_name` returns `true` if the module's name has been
updated succesfully, `false` otherwise, e.g. if the name is invalid,
or if it's not possible to update it (e.g. if the module is already
instantiated).