### PR TITLE
Fix warning about casting from pointer to integer of different size.

### DIFF
--- a/example/finalize.c
+++ b/example/finalize.c
@@ -12,7 +12,7 @@ const int iterations = 100000;
 int live_count = 0;
 
 void finalize(void* data) {
-  int i = (intptr_t)data;
+  intptr_t i = (intptr_t)data;
   if (i % (iterations / 10) == 0) printf("Finalizing #%" PRIdPTR "...\n", i);
   --live_count;
 }

--- a/example/finalize.c
+++ b/example/finalize.c
@@ -12,8 +12,8 @@ const int iterations = 100000;
 int live_count = 0;
 
 void finalize(void* data) {
-  int i = (int)data;
-  if (i % (iterations / 10) == 0) printf("Finalizing #%d...\n", i);
+  int i = (intptr_t)data;
+  if (i % (iterations / 10) == 0) printf("Finalizing #%" PRIdPTR "...\n", i);
   --live_count;
 }
 


### PR DESCRIPTION
Fixes: 
```
/home/nicholas/wasmer/lib/c-api/tests/wasm_c_api/wasm-c-api/example/finalize.c: In function ‘finalize’:
/home/nicholas/wasmer/lib/c-api/tests/wasm_c_api/wasm-c-api/example/finalize.c:15:11: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   15 |   int i = (int)data;
      |           ^
cc1: all warnings being treated as errors
```