### PR TITLE
Add validate operation to hello example

### DIFF
--- a/example/hello.c
+++ b/example/hello.c
@@ -41,6 +41,13 @@ int main(int argc, const char* argv[]) {
   }
   fclose(file);
 
+  // Validate.
+  printf("Validating module...\n");
+  if (!wasm_module_validate(store, &binary)) {
+    printf("> Error validating module!\n");
+    return 1;
+  }
+
   // Compile.
   printf("Compiling module...\n");
   own wasm_module_t* module = wasm_module_new(store, &binary);

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -38,6 +38,13 @@ void run() {
     exit(1);
   }
 
+  // Validate.
+  std::cout << "Validating module..." << std::endl;
+  if (!wasm::Module::validate(store, binary)) {
+    std::cout << "> Error validating module!" << std::endl;
+    exit(1);
+  }
+
   // Compile.
   std::cout << "Compiling module..." << std::endl;
   auto module = wasm::Module::make(store, binary);


### PR DESCRIPTION
Add validation to the list of basic operations showcased by the hello example, to ensure it is not missed out by implementors (see [V8 issue](https://bugs.chromium.org/p/v8/issues/detail?id=12941) and [patch](https://chromium-review.googlesource.com/c/v8/v8/+/3692020))