### PR TITLE
Support MinGW

### DIFF
--- a/include/wasm.h
+++ b/include/wasm.h
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 #ifndef WASM_API_EXTERN
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define WASM_API_EXTERN __declspec(dllimport)
 #else
 #define WASM_API_EXTERN

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -12,7 +12,7 @@
 #include <string>
 
 #ifndef WASM_API_EXTERN
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define WASM_API_EXTERN __declspec(dllimport)
 #else
 #define WASM_API_EXTERN


### PR DESCRIPTION
Compiling using MinGW requires `.a` library not `.dll`. Also see https://github.com/wasmerio/wasmer/pull/3849.