### PR TITLE
Add missing include headers

### DIFF
--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <limits>
 #include <string>
 


### PR DESCRIPTION
This is for C++ modules build in chromium.