### PR TITLE
Fix new-delete-type-mismatch in WASM_DEFINE_OWN and re-enable C tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,5 @@ jobs:
         run: make wasm
       - name: Run C++ tests
         run: make cc
-      # TODO: C memory management seems to have broken entirely for yet unknown reasons
-      #- name: Run C tests
-      #  run: make c
+      - name: Run C tests
+        run: make c

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -29,7 +29,7 @@ struct borrowed_vec {
   struct wasm_##name##_t : Name {}; \
   \
   void wasm_##name##_delete(wasm_##name##_t* x) { \
-    delete x; \
+    if (x) destroyer{}(static_cast<Name*>(x)); \
   } \
   \
   extern "C++" inline auto hide_##name(Name* x) -> wasm_##name##_t* { \


### PR DESCRIPTION
wasm.hh types (FuncType, GlobalType, etc.) are empty pimpl handles — sizeof is 1. The actual allocated object is the concrete impl (e.g. FuncTypeImpl, 40 bytes). Using `delete x` on the derived wrapper struct triggered ASAN new-delete-type-mismatch because the sized operator delete received sizeof(wasm_functype_t)=1 instead of sizeof(FuncTypeImpl)=40.

Fix: use destroyer{}(static_cast<Name*>(x)) which routes through Name::destroy() -> delete impl(this), the correct cleanup path.

Re-enable `make c` in CI now that the memory management issue is fixed.